### PR TITLE
Initial Changes to svg version - addressing Tom's comments

### DIFF
--- a/draft-ietf-detnet-yang-13.xml
+++ b/draft-ietf-detnet-yang-13.xml
@@ -1,0 +1,24032 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE rfc SYSTEM "rfc2629-xhtml.ent">
+<?rfc toc="yes"?>
+<?rfc tocompact="yes"?>
+<?rfc tocdepth="3"?>
+<?rfc tocindent="yes"?>
+<?rfc symrefs="yes"?>
+<?rfc sortrefs="yes"?>
+<?rfc comments="yes"?>
+<?rfc inline="yes"?>
+<?rfc compact="yes"?>
+<?rfc subcompact="no"?>
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" category="std" docName="draft-ietf-detnet-yang-13" ipr="trust200902" submissionType="IETF" obsoletes="" updates="" xml:lang="en" tocInclude="true" tocDepth="3" symRefs="true" sortRefs="true" version="3">
+  <!-- xml2rfc v2v3 conversion 3.7.0 -->
+  <front>
+    <title abbrev="draft-ietf-detnet-yang-13">Deterministic Networking
+    (DetNet) YANG Model</title>
+    <seriesInfo name="Internet-Draft" value="draft-ietf-detnet-yang-13"/>
+    <author fullname="Xuesong Geng" initials="X." surname="Geng">
+      <organization>Huawei Technologies</organization>
+      <address>
+        <postal>
+          <street/>
+          <city/>
+          <code/>
+          <country/>
+        </postal>
+        <email>gengxuesong@huawei.com</email>
+      </address>
+    </author>
+    <author fullname="Mach(Guoyi) Chen" initials="M." surname="Chen">
+      <organization>Huawei Technologies</organization>
+      <address>
+        <postal>
+          <street/>
+          <city/>
+          <code/>
+          <country/>
+        </postal>
+        <email>mach.chen@huawei.com</email>
+      </address>
+    </author>
+    <author fullname="Yeoncheol Ryoo" initials="Y." surname="Ryoo">
+      <organization>ETRI</organization>
+      <address>
+        <postal>
+          <street/>
+          <city/>
+          <region/>
+          <code/>
+          <country/>
+        </postal>
+        <phone/>
+        <email>dbduscjf@etri.re.kr</email>
+        <uri/>
+      </address>
+    </author>
+    <author fullname="Don Fedyk" initials="D." surname="Fedyk">
+      <organization>LabN Consulting, L.L.C.</organization>
+      <address>
+        <postal>
+          <street/>
+          <city/>
+          <region/>
+          <code/>
+          <country/>
+        </postal>
+        <phone/>
+        <email>dfedyk@labn.net</email>
+        <uri/>
+      </address>
+    </author>
+    <author fullname="Reshad Rahman" initials="R." surname="Rahman">
+      <organization>Individual</organization>
+      <address>
+        <postal>
+          <street/>
+          <city/>
+          <region/>
+          <code/>
+          <country/>
+        </postal>
+        <phone/>
+        <email>reshad@yahoo.com</email>
+        <uri/>
+      </address>
+    </author>
+    <author fullname="Zhenqiang Li" initials="Z." surname="Li">
+      <organization>China Mobile</organization>
+      <address>
+        <postal>
+          <street/>
+          <city/>
+          <code/>
+          <country/>
+        </postal>
+        <email>lizhenqiang@chinamobile.com</email>
+      </address>
+    </author>
+    <date/>
+    <abstract>
+      <t>This document contains the specification for the Deterministic Networking
+     YANG Model for configuration and operational data for DetNet Flows. 
+      The model allows for provisioning of
+      end-to-end DetNet service along the path without dependency on any
+      signaling protocol. It also specifies operational status for
+      flows.</t>
+      <t>The YANG module defined in this document conforms to the Network
+      Management Datastore Architecture (NMDA).</t>
+    </abstract>
+    <note>
+      <name>Requirements Language</name>
+      <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
+      NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED",
+      "MAY", and "OPTIONAL" in this document are to be interpreted as
+      described in BCP 14 
+      <xref target="RFC2119"></xref>
+      <xref target="RFC8174"></xref>
+      when, and only when, they
+      appear in all capitals, as shown here.</t>
+    </note>
+  </front>
+  <middle>
+    <section numbered="true" toc="default">
+      <name>Introduction</name>
+      <t>DetNet (Deterministic Networking) provides a capability to carry
+      specified unicast or multicast data flows for real-time applications
+      with extremely low packet loss rates and assured maximum end-to-end
+      delivery latency. A description of the general background and concepts
+      of DetNet can be found in <xref target="RFC8655" format="default"/>.</t>
+      <t>This document defines a YANG model for DetNet based on YANG data
+      types and modeling language defined in <xref target="RFC6991" format="default"/> and
+      <xref target="RFC7950" format="default"/>. DetNet service, which is designed for
+      describing the characteristics of services being provided for
+      application flows over a network, and DetNet configuration, which is
+      designed for DetNet flow path establishment, flow status reporting, and
+      DetNet functions configuration in order to achieve end-to-end bounded
+      latency and zero congestion loss, are both included in this
+      document.</t>
+    </section>
+    <section numbered="true" toc="default">
+      <name>Terminology</name>
+      <t>This document uses the terminology defined in <xref target="RFC8655" format="default"> </xref>.</t>
+    </section>
+    <section numbered="true" toc="default">
+      <name>DetNet YANG Module</name>
+      <t>The DetNet YANG module includes DetNet App-flow,
+      DetNet Service Sub-layer, and DetNet Forwarding Sub-layer
+      configuration and operational objects. 
+      The corresponding attributes used in different sub-layers
+      are defined in Section 3.1, 3.2, 3.3 respectively.</t>
+      <section numbered="true" toc="default">
+        <name>DetNet Application Flow YANG Attributes</name>
+        <t>DetNet application flow is responsible for mapping between
+        application flows and DetNet flows at the edge node(egress/ingress
+        node). The application flows can be either layer 2 or layer 3
+        flows. To map a flow at the User Network Interface (UNI), the
+        corresponding attributes are defined in <xref target="RFC9016" format="default"/>.</t>
+      </section>
+      <section numbered="true" toc="default">
+        <name>DetNet Service Sub-layer YANG Attributes</name>
+        <t>DetNet service functions, e.g., DetNet tunnel
+        initialization/termination and service protection, are provided in
+        the DetNet service sub-layer. To support these functions, the following
+        service attributes need to be configured:</t>
+        <ul spacing="normal">
+          <li>DetNet flow identification</li>
+          <li>Service function indication, indicates which service function
+            will be invoked at a DetNet edge, relay node or end station.
+            (DetNet tunnel initialization or termination are default functions
+            in DetNet service layer, so there is no need for explicit
+            indication). The corresponding arguments for service functions
+            also needs to be defined.</li>
+        </ul>
+      </section>
+      <section numbered="true" toc="default">
+        <name>DetNet Forwarding Sub-layer YANG Attributes</name>
+        <t>As defined in <xref target="RFC8655" format="default"/>, DetNet forwarding sub-layer
+        optionally provides congestion protection for DetNet flows over paths
+        provided by the underlying network. Explicit route is another
+        mechanism that is used by DetNet to avoid temporary interruptions
+        caused by the convergence of routing or bridging protocols, and it is
+        also implemented at the DetNet forwarding sub-layer.</t>
+        <t>To support congestion protection and explicit route, the following
+        transport layer related attributes are necessary:</t>
+        <ul spacing="normal">
+          <li>Flow Specification and Traffic Requirements, refers to <xref target="RFC9016" format="default"/>. These may used for
+            resource reservation, flow shaping, filtering and policing by 
+            a control plane or other network management and control mechanisms.
+            </li>
+          <li>Since this model programs the data plane existing explicit route
+            mechanisms can be reused. If a static MPLS tunnel is used as the
+            transport tunnel, the configuration need to be at every transit
+            node along the path. For an IP based path, the static configuration
+            is similar to the static MPLS case.  This document provides
+            data-plane configuration of IP addresses or MPLS labels
+            but it does not provide control plane mapping or other
+            aspects. 
+            </li>
+        </ul>
+      </section>
+    </section>
+    <section numbered="true" toc="default">
+      <name>DetNet Flow Aggregation</name>
+      <t>
+      DetNet provides the capability of flow aggregation to improve
+      scalability of DetNet data, management and control planes.  Aggregated
+      flows can be viewed by the some DetNet nodes as individual DetNet flows.
+      When aggregating DetNet flows, the flows should be compatible: if
+      bandwidth reservations are used, the reservation should be a reasonable
+      representation of  the individual reservations; if maximum delay bounds
+      are used, the system should ensure that the aggregate does not exceed the
+      delay bounds of the individual flows.
+      </t>
+      <t>
+       The DetNet YANG model defined in this document supports DetNet flow
+       aggregation with the following functions:
+      </t>
+      <ul spacing="normal">
+        <li>
+      Aggregation flow encapsulation/decapsulation/identification
+       </li>
+        <li>
+      Mapping individual DetNet flows to an aggregated flow
+       </li>
+        <li>
+      Changing traffic specification parameters for aggregated flow
+       </li>
+      </ul>
+      <t>
+         The following cases of DetNet aggregation are supported:
+      </t>
+      <ul spacing="normal">
+        <li>
+       Ingress node aggregates App flows into a service sub-layer of DetNet flow  
+       </li>
+        <li>
+       In ingress node, the service sub-layers of DetNet flows are aggregated into a forwarding sub-layer  
+       </li>
+        <li>
+       In ingress node, the service sub-layers of DetNet flows are aggregated into a service sub-layer of an aggregated DetNet flow 
+       </li>
+        <li>
+       Relay node aggregates the forwarding sub-layers DetNet flows into a forwarding sub-layer
+       </li>
+        <li>
+       Relay node aggregates the service sub-layers of DetNet flows into a forwarding sub-layer
+       </li>
+        <li>
+       Relay node aggregates the service sub-layers of DetNet flows into a service sub-layer of Aggregated DetNet flow
+       </li>
+        <li>
+       Relay node aggregates the forwarding sub-layers of DetNet flow into a service sub-layer of Aggregated DetNet flow
+       </li>
+        <li>
+       Transit node aggregates the forwarding sub-layers of DetNet flows into a forwarding sub-layer
+       </li>
+      </ul>
+      <t>
+       Traffic requirements and traffic specification may be tracked for
+       individual or aggregate flows but reserving resources and tracking the
+       services in the aggregated flow is out of scope.
+      </t>
+    </section>
+    <section numbered="true" toc="default">
+      <name>DetNet YANG Structure Considerations</name>
+      <t/>
+      <t>The picture shows that the general structure of the DetNet YANG
+      Model:</t>
+      <artwork name="" type="" align="left" alt=""><![CDATA[                 
+                  +-----------+
+                  |ietf-detnet|
+                  +-----+-----+
+                        |
+          +-------------+---------------+-------------------+
+          |             |               |                   |  
+    +-----+-----+ +-----+-----+ +-------+------+            | 
+    | App Flows | |service s-l| |forwarding s-l|            |
+    +-----+-----+ +-----+-----+ +-------+------+            |
+          |             |               |                   |
+    +-----+-----+ +-----+-----+ +-------+------+   +--------+-------+ 
+    | Ref to TR | | Ref to TR | |  Ref to TR   |   | Traffic Profile|
+    +-----------+ +-----------+ +--------------+   +----------------+
+]]></artwork>
+      <t>There are three instances in DetNet YANG Model: App-flow instance,
+      service sub-layer instance and forwarding sub-layer instance,
+      respectively corresponding to four parts of DetNet functions defined in
+      section 3. </t>
+    </section>
+    <section numbered="true" toc="default">
+      <name>DetNet Configuration YANG Structures</name>
+      <artwork name="" type="" align="left" alt=""><![CDATA[
+module: ietf-detnet
+  +--rw detnet
+     +--rw traffic-profile* [profile-name]
+     |  +--rw profile-name            string
+     |  +--rw traffic-requirements
+     |  +--rw flow-spec
+     |  +--ro member-apps*            app-flow-ref
+     |  +--ro member-services*        service-sub-layer-ref
+     |  +--ro member-fwd-sublayers*   forwarding-sub-layer-ref
+
+     +--rw app-flows
+     |  +--rw app-flow* [name]
+     |     +--rw name                        string
+     |     +--rw app-flow-bidir-congruent?   boolean
+     |     +--ro outgoing-service?           service-sub-layer-ref
+     |     +--ro incoming-service?           service-sub-layer-ref
+     |     +--rw traffic-profile?            traffic-profile-ref
+     |     +--rw ingress
+     |     |  +--rw name?                  string
+     |     |  +--ro app-flow-status?       identityref
+     |     |  +--rw interface?             if:interface-ref
+     |     |  +--rw (data-flow-type)?
+     |     +--rw egress
+     |        +--rw name?             string
+     |        +--rw (application-type)?
+
+     +--rw service-sub-layer
+     |  +--rw service-sub-layer-list* [name]
+     |     +--rw name                      string
+     |     +--rw service-rank?             uint8
+     |     +--rw traffic-profile?          traffic-profile-ref
+     |     +--rw service-protection
+     |     |  +--rw service-protection-type?   service-protection-type
+     |     |  +--rw sequence-number-length?    sequence-number-field
+     |     +--rw service-operation-type?   service-operation-type
+     |     +--rw incoming-type
+     |     |  +--rw (incoming-type)
+     |     +--rw outgoing-type
+     |        +--rw (outgoing-type)
+
+
+     +--rw forwarding-sub-layer
+        +--rw forwarding-sub-layer-list* [name]
+           +--rw name                         string
+           +--rw traffic-profile?             traffic-profile-ref
+           +--rw forwarding-operation-type?
+           |       forwarding-operations-type
+           +--rw incoming-type
+           |  +--rw (incoming-type)
+           |     +--:(service-sub-layer)
+           |     |  +--rw service-sub-layer
+           |     |     +--rw service-sub-layer*
+           |     |             service-sub-layer-ref
+           |     +--:(forwarding-aggregation)
+           |     |  +--rw forwarding-aggregation
+           |     |     +--rw forwarding-sub-layer*
+           |     |             forwarding-sub-layer-ref
+           |     +--:(forwarding-id)
+           |        +--rw forwarding-id
+           |           +--rw interface?
+           |           |       if:interface-ref
+           |           +--rw (detnet-flow-type)?
+           +--rw outgoing-type
+              +--rw (outgoing-type)
+                 +--:(interface)
+                 |  +--rw interface
+                 +--:(service-aggregation)
+                 |  +--rw service-aggregation
+                 +--:(forwarding-sub-layer)
+                 |  +--rw forwarding-sub-layer
+                 |     +--rw aggregation-forwarding-sub-layer?
+                 +--:(service-sub-layer)
+                 |  +--rw service-sub-layer
+                 |     +--rw service-sub-layer*
+                 |             service-sub-layer-ref
+                 +--:(forwarding-disaggregation)
+                    +--rw forwarding-disaggregation
+                       +--rw forwarding-sub-layer*
+                               forwarding-sub-layer-ref
+              ]]></artwork>
+    </section>
+    <section numbered="true" toc="default">
+      <name>DetNet Configuration YANG Model</name>
+      <sourcecode name="" type="" markers="true"><![CDATA[
+module ietf-detnet {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-detnet";
+  prefix dnet;
+
+  import ietf-yang-types {
+    prefix yang;
+    reference
+      "RFC 6991 - Common YANG Data Types.";
+  }
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991 - Common YANG Data Types.";
+  }
+  import ietf-ethertypes {
+    prefix ethertypes;
+    reference
+      "RFC 8519 - YANG Data Model for Network Access Control
+                  Lists (ACLs).";
+  }
+  import ietf-routing-types {
+    prefix rt-types;
+    reference
+      "RFC 8294 - Common YANG Data Types for the Routing Area.";
+  }
+  import ietf-packet-fields {
+    prefix packet-fields;
+    reference
+      "RFC 8519 - YANG Data Model for Network Access Control Lists
+       (ACLs).";
+  }
+  import ietf-interfaces {
+    prefix if;
+    reference
+      "RFC 8343 - A YANG Data Model for Interface Management.";
+  }
+  import ieee802-dot1q-types {
+    prefix dot1q-types;
+    reference
+      "IEEE 802.1Qcx-2020 - IEEE Standard for Local and Metropolitan
+       Area Networks--Bridges and Bridged Networks Amendment 33: YANG
+       Data Model for Connectivity Fault Management.";
+  }
+
+  organization
+    "IETF DetNet Working Group";
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/detnet/>
+     WG List:  <mailto: detnet@ietf.org>
+
+     Editor:   Xuesong Geng
+                <mailto:gengxuesong@huawei.com>
+
+     Editor:   Yeoncheol Ryoo
+                <mailto:dbduscjf@etri.re.kr>
+
+     Editor:   Don Fedyk
+                <mailto:dfedyk@labn.net>;
+
+     Editor:   Reshad Rahman
+                <mailto:reshad@yahoo.com>
+
+     Editor:   Mach Chen
+                <mailto:mach.chen@huawei.com>
+
+     Editor:   Zhenqiang Li
+                <mailto:lizhenqiang@chinamobile.com>";
+  description
+    "This YANG module describes the parameters needed
+     for DetNet flow configuration and flow status
+     reporting.
+     
+     Copyright (c) 2021 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC XXXX
+     (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+     for full legal notices.
+     
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here. ";
+     
+
+  revision 2021-02-17 {
+    description
+      "initial revision";
+    reference
+      "RFC XXXX: Determistic Networking (DetNet) YANG Model";
+  }
+
+  identity app-status {
+    description
+      "Base identity from which all application-status
+       status types are derived.";
+    reference
+      "RFC 9016 Section 5.8";
+  }
+
+  identity none {
+    base app-status;
+    description
+      "This Application has no status. This type of status is
+       expected when the configuration is incomplete.";
+    reference
+      "RFC 9016 Section 5.8";
+  }
+
+  identity ready {
+    base app-status;
+    description
+      "Application ingress/egress ready.";
+    reference
+      "RFC 9016 Section 5.8";
+  }
+
+  identity failed {
+    base app-status;
+    description
+      "Application ingres/egresss failed.";
+    reference
+      "RFC 9016 Section 5.8";
+  }
+
+  identity out-of-service {
+    base app-status;
+    description
+      "Application Administratively blocked.";
+    reference
+      "RFC 9016 Section 5.8";
+  }
+
+  identity partial-failed {
+    base app-status;
+    description
+      "This is an Application with one or more Egress ready, and one
+       or more Egress failed.  The DetNet flow can be used if the
+       Ingress is Ready.";
+    reference
+      "RFC 9016 Section 5.8";
+  }
+
+  typedef app-flow-ref {
+    type leafref {
+      path "/dnet:detnet"
+         + "/dnet:app-flows"
+         + "/dnet:app-flow"
+         + "/dnet:name";
+    }
+    description
+      "This is an Application Reference.";
+  }
+
+  typedef service-sub-layer-ref {
+    type leafref {
+      path "/dnet:detnet"
+         + "/dnet:service-sub-layer"
+         + "/dnet:service-sub-layer-list"
+         + "/dnet:name";
+    }
+    description
+      "This is a Service sub-layer Reference.";
+  }
+
+  typedef forwarding-sub-layer-ref {
+    type leafref {
+      path "/dnet:detnet"
+         + "/dnet:forwarding-sub-layer"
+         + "/dnet:forwarding-sub-layer-list"
+         + "/dnet:name";
+    }
+    description
+      "This is a Forwarding sub-layer Reference.";
+  }
+
+  typedef traffic-profile-ref {
+    type leafref {
+      path "/dnet:detnet"
+         + "/dnet:traffic-profile"
+         + "/dnet:profile-name";
+    }
+    description
+      "This is a Traffic Profile Reference.";
+  }
+
+  typedef ipsec-spi {
+    type uint32 {
+      range "1..max";
+    }
+    description
+      "IPsec Security Parameters Index.";
+    reference
+      "IETF RFC 6071";
+  }
+
+  typedef service-operation-type {
+    type enumeration {
+      enum service-initiation {
+        description
+          "This is an initiating service sub-layer encapsulation.";
+      }
+      enum service-termination {
+        description
+          "Operation for DetNet service sub-layer decapsulation.";
+      }
+      enum service-relay {
+        description
+          "Operation for DetNet service sub-layer swap.";
+      }
+      enum non-detnet {
+        description
+          "No operation for DetNet service sub-layer.";
+      }
+    }
+    description
+      "Operation type identifies the behavior for this service
+       sub-layer instance. Operations are described as unidirectional
+       but a service sub-layer may combine operation types.";
+  }
+
+  typedef forwarding-operations-type {
+    type enumeration {
+      enum impose-and-forward {
+        description
+          "This operation impose outgoing label(s) and forward to
+           next-hop.";
+        reference
+          " A YANG Data Model for MPLS Base
+            draft-ietf-mpls-base-yang.";
+      }
+      enum pop-and-forward {
+        description
+          "This operation pops the incoming label and forwards to
+           the next-hop.";
+        reference
+          " A YANG Data Model for MPLS Base
+            draft-ietf-mpls-base-yang.";
+      }
+      enum pop-impose-and-forward {
+        description
+          "This operation pops the incoming label, imposes one or
+           more outgoing label(s) and forwards to the next-hop.";
+        reference
+          " A YANG Data Model for MPLS Base
+            draft-ietf-mpls-base-yang.";
+      }
+      enum swap-and-forward {
+        description
+          "This operation swaps incoming label, with an outgoing
+           label and forwards to the next-hop.";
+        reference
+          " A YANG Data Model for MPLS Base
+            draft-ietf-mpls-base-yang.";
+      }
+      enum forward {
+        description
+          "This operation forward to next-hop.";
+      }
+      enum pop-and-lookup {
+        description
+          "This operation pops incoming label and performs a
+           lookup.";
+      }
+    }
+    description
+      "MPLS operations types.  This is an enum modeled after the
+       MPLS enum.  The first 4 enums are the same as A YANG Data
+       Model for MPLS Base.  draft-ietf-mpls-base-yang.";
+  }
+
+  typedef service-protection-type {
+    type enumeration {
+      enum none {
+        description
+          "No service protection provided.";
+      }
+      enum replication {
+        description
+          "A Packet Replication Function (PRF) replicates DetNet
+           flow packets and forwards them to one or more next hops in
+           the DetNet domain.  The number of packet copies sent to
+           each next hop is a DetNet flow specific parameter at the
+           node doing the replication.  PRF can be implemented by an
+           edge node, a relay node, or an end system.";
+      }
+      enum elimination {
+        description
+          "A Packet Elimination Function (PEF) eliminates duplicate
+           copies of packets to prevent excess packets flooding the
+           network or duplicate packets being sent out of the DetNet
+           domain.  PEF can be implemented by an edge node, a relay
+           node, or an end system.";
+      }
+      enum ordering {
+        description
+          "A Packet Ordering Function (POF) re-orders packets within
+           a DetNet flow that are received out of order.  This
+           function can be implemented by an edge node, a relay node,
+           or an end system.";
+      }
+      enum elimination-ordering {
+        description
+          "A combination of PEF and POF that can be implemented by
+           an edge node, a relay node, or an end system.";
+      }
+      enum elimination-replication {
+        description
+          "A combination of PEF and PRF that can be implemented by
+           an edge node, a relay node, or an end system.";
+      }
+      enum elimination-ordering-replication {
+        description
+          "A combination of PEF, POF and PRF that can be implemented
+           by an edge node, a relay node, or an end system.";
+      }
+    }
+    description
+      "This typedef describes the service protection types.";
+  }
+
+  typedef sequence-number-generation-type {
+    type enumeration {
+      enum copy-from-app-flow {
+        description
+          "This type means copy the app-flow sequence number to the
+           DetNet-flow.";
+      }
+      enum generate-by-detnet-flow {
+        description
+          "This type means generate the sequence number by the
+           DetNet flow.";
+      }
+    }
+    description
+      "An enumeration for the sequence number behaviors supported.";
+  }
+
+  typedef sequence-number-field {
+    type enumeration {
+      enum zero-sn {
+        description
+          "No DetNet sequence number field is used.";
+      }
+      enum short-sn {
+        value 16;
+        description
+          "A 16-bit DetNet sequence number field is used.";
+      }
+      enum long-sn {
+        value 28;
+        description
+          "A 28-bit DetNet sequence number field is used.";
+      }
+    }
+    description
+      "This type captures the sequence number behavior.";
+  }
+
+  grouping ip-header {
+    description
+      "This grouping captures the IPv4/IPv6 packet header
+       information. it is modeled after existing fields.";
+    leaf src-ip-address {
+      type inet:ip-address-no-zone;
+      description
+        "The source IP address in the header.";
+      reference
+        "RFC 6991 Common YANG Data Types";
+    }
+    leaf dest-ip-address {
+      type inet:ip-address-no-zone;
+      description
+        "The destination IP address in the header.";
+      reference
+        "RFC 6991 Common YANG Data Types";
+    }
+    leaf protocol-next-header {
+      type uint8;
+      description
+        "Internet Protocol number.  Refers to the protocol of the
+         payload.  In IPv6, this field is known as 'next-header',
+         and if extension headers are present, the protocol is
+         present in the 'upper-layer' header.";
+      reference
+        "RFC 791: Internet Protocol
+         RFC 8200: Internet Protocol, Version 6 (IPv6)
+         Specification.";
+    }
+    leaf dscp {
+      type inet:dscp;
+      description
+        "The traffic class value in the header.";
+      reference
+        "RFC 6991 Common YANG Data Types";
+    }
+    leaf flow-label {
+      type inet:ipv6-flow-label;
+      description
+        "The flow label value of the header.IPV6 only.";
+      reference
+        "RFC 6991 Common YANG Data Types";
+    }
+    leaf source-port {
+      type inet:port-number;
+      description
+        "The source port number.";
+      reference
+        "RFC 6991 Common YANG Data Types";
+    }
+    leaf destination-port {
+      type inet:port-number;
+      description
+        "The destination port number.";
+      reference
+        "RFC 6991 Common YANG Data Types";
+    }
+  }
+
+  grouping l2-header {
+    description
+      "The Ethernet or TSN packet header information.";
+    leaf source-mac-address {
+      type yang:mac-address;
+      description
+        "The source MAC address value of the Ethernet header.";
+    }
+    leaf destination-mac-address {
+      type yang:mac-address;
+      description
+        "The destination MAC address value of the Ethernet header.";
+    }
+    leaf ethertype {
+      type ethertypes:ethertype;
+      description
+        "The Ethernet packet type value of the Ethernet header.";
+    }
+    leaf vlan-id {
+      type dot1q-types:vlanid;
+      description
+        "The VLAN value of the Ethernet header.";
+      reference
+        "IEEE 802.1Qcx-2020.";
+    }
+    leaf pcp {
+      type dot1q-types:priority-type;
+      description
+        "The priority value of the Ethernet header.";
+      reference
+        "IEEE 802.1Qcx-2020.";
+    }
+  }
+
+  grouping destination-ip-port-id {
+    description
+      "The TCP/UDP port(source/destination) identification
+       information.";
+    container destination-port {
+      uses packet-fields:port-range-or-operator;
+      description
+         "This grouping captures the destination port fields.";
+    }
+  }
+
+  grouping source-ip-port-id {
+    description
+      "The TCP/UDP port(source/destination) identification
+       information.";
+    container source-port {
+      uses packet-fields:port-range-or-operator;
+      description
+         "This grouping captures the source port fields.";
+    }
+  }
+
+  grouping ip-flow-id {
+    description
+      "The IPv4/IPv6 packet header identification information.";
+    leaf src-ip-prefix {
+      type inet:ip-prefix;
+      description
+        "The source IP prefix.";
+      reference
+        "RFC 6991 Common YANG Data Types";
+    }
+    leaf dest-ip-prefix {
+      type inet:ip-prefix;
+      description
+        "The destination IP prefix.";
+      reference
+        "RFC 6991 Common YANG Data Types";
+    }
+    leaf protocol-next-header {
+      type uint8;
+      description
+        "Internet Protocol number.  Refers to the protocol of the
+         payload.  In IPv6, this field is known as 'next-header', and
+         if extension headers are present, the protocol is present in
+         the 'upper-layer' header.";
+      reference
+        "RFC 791: Internet Protocol
+          RFC 8200: Internet Protocol, Version 6 (IPv6)
+         Specification.";
+    }
+    leaf dscp {
+      type inet:dscp;
+      description
+        "The traffic class value in the header.";
+      reference
+        "RFC 6991 Common YANG Data Types";
+    }
+    leaf flow-label {
+      type inet:ipv6-flow-label;
+      description
+        "The flow label value of the header.";
+      reference
+        "RFC 6991 Common YANG Data Types";
+    }
+    uses source-ip-port-id;
+    uses destination-ip-port-id;
+    leaf ipsec-spi {
+      type ipsec-spi;
+      description
+      "IPsec Security Parameters Index of the Security
+       Association.";
+      reference
+        "IETF RFC 6071 IP Security (IPsec) and Internet Key Exchange
+         (IKE) Document Roadmap.";
+    }
+  }
+
+  grouping mpls-flow-id {
+    description
+      "The MPLS packet header identification information.";
+    choice label-space {
+      description
+        "Designates the label space being used.";
+      case context-label-space {
+        uses rt-types:mpls-label-stack;
+      }
+      case platform-label-space {
+        leaf label {
+          type rt-types:mpls-label;
+          description
+           "This is the case for Platform label space.";
+        }
+      }
+    }
+  }
+
+  grouping data-flow-spec {
+    description
+      "app-flow identification.";
+    choice data-flow-type {
+      description
+        "The Application flow type choices.";
+      container tsn-app-flow {
+        uses l2-header;
+        description
+          "The L2 header for application.";
+      }
+      container ip-app-flow {
+        uses ip-flow-id;
+        description
+          "The IP header for application.";
+      }
+      container mpls-app-flow {
+        uses mpls-flow-id;
+        description
+          "The MPLS header for application.";
+      }
+    }
+  }
+
+  grouping detnet-flow-spec {
+    description
+      "detnet-flow identification.";
+    choice detnet-flow-type {
+      description
+        "The Detnet flow type choices.";
+      case ip-detnet-flow {
+        uses ip-flow-id;
+      }
+      case mpls-detnet-flow {
+        uses mpls-flow-id;
+      }
+    }
+  }
+
+  grouping app-flows-group {
+    description
+      "Incoming or outgoing app-flow reference group.";
+    leaf-list app-flow-list {
+      type app-flow-ref;
+      description
+        "List of ingress or egress app-flows.";
+    }
+  }
+
+  grouping service-sub-layer-group {
+    description
+      "Incoming or outgoing service sub-layer reference group.";
+    leaf-list service-sub-layer {
+      type service-sub-layer-ref;
+      description
+        "List of incoming or outgoing service sub-layers that have
+         to aggregate or disaggregate.";
+    }
+  }
+
+  grouping forwarding-sub-layer-group {
+    description
+      "Incoming or outgoing forwarding sub-layer reference group.";
+    leaf-list forwarding-sub-layer {
+      type forwarding-sub-layer-ref;
+      description
+        "List of incoming or outgoing forwarding sub-layers that
+         have to aggregate or disaggregate.";
+    }
+  }
+
+  grouping detnet-header {
+    description
+      "DetNet header info for DetNet encapsulation or swap.";
+    choice header-type {
+      description
+      "The choice of DetNet header type.";
+      case detnet-mpls-header {
+        description
+          "MPLS label stack for DetNet MPLS encapsulation or
+           forwarding.";
+        uses rt-types:mpls-label-stack;
+      }
+      case detnet-ip-header {
+        description
+          "IPv4/IPv6 packet header for DetNet IP encapsulation.";
+        uses ip-header;
+      }
+    }
+  }
+
+  grouping detnet-app-next-hop-content {
+    description
+      "Generic parameters of DetNet next hops.";
+    choice next-hop-options {
+      mandatory true;
+      description
+        "Options for next hops.  It is expected that further cases
+         will be added through
+         augments from other modules, e.g., for recursive
+         next hops.";
+      case simple-next-hop {
+        description
+          "This case represents a simple next hop consisting of the
+           next-hop address and/or outgoing interface.
+           Modules for address families MUST augment this case with a
+           leaf containing a next-hop address of that address
+           family.";
+        leaf outgoing-interface {
+          type if:interface-ref;
+          description
+            "The outgoing interface, if this is a whole interface.";
+        }
+        choice flow-type {
+          description 
+            "The flow type choices.";
+          case ip {
+            leaf next-hop-address {
+              type inet:ip-address-no-zone;
+              description
+               "The IP next hop case.";
+            }
+          }
+          case mpls {
+            uses rt-types:mpls-label-stack;
+            description
+              "The MPLS Label stack next hop case.";
+          }
+        }
+      }
+      case next-hop-list {
+        description
+          "Container for multiple next hops.";
+        list next-hop {
+          key "hop-index";
+          description
+            "An entry in a next-hop list.  Modules for address
+             families MUST augment this list with a leaf containing a
+             next-hop address of that address family.";
+          leaf hop-index {
+            type uint8;
+            description
+              "A user-specified identifier utilized to uniquely
+               reference the next-hop entry in the next-hop list.
+               The value of this index has no semantic meaning other
+               than for referencing the entry.";
+          }
+          leaf outgoing-interface {
+            type if:interface-ref;
+            description
+              "Name of the outgoing interface.";
+          }
+          choice flow-type {
+            description
+              "The flow types supported."; 
+            case ip {
+              leaf next-hop-address {
+                type inet:ip-address-no-zone;
+                description
+                  "This is the IP flow type next hop.";
+              }
+            }
+            case mpls {
+              uses rt-types:mpls-label-stack;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping detnet-forwarding-next-hop-content {
+    description
+      "Generic parameters of DetNet next hops.";
+    choice next-hop-options {
+      mandatory true;
+      description
+        "Options for next hops.
+         It is expected that further cases will be added through
+         augments from other modules, e.g., for recursive
+         next hops.";
+       case simple-next-hop {
+        description
+          "This case represents a simple next hop consisting of the
+           next-hop address and/or outgoing interface.
+           Modules for address families MUST augment this case with a
+           leaf containing a next-hop address of that address
+           family.";
+        leaf outgoing-interface {
+          type if:interface-ref;
+          description
+            "This is the interface as an outgoing type.";
+        }
+        choice flow-type {
+          description
+            "These are the flow type next hop choices.";
+          case ip {
+            choice operation-type {
+              description
+                "This is the IP forwarding operation choices.";
+              case ip-forwarding {
+                leaf next-hop-address {
+                  type inet:ip-address-no-zone;
+                  description
+                    "This is an IP address as a next hop.";
+                }
+              }
+              case mpls-over-ip-encapsulation {
+                uses ip-header;
+              }
+            }
+          }
+          case mpls {
+            uses rt-types:mpls-label-stack;
+          }
+        }
+      }
+      case next-hop-list {
+        description
+          "Container for multiple next hops.";
+        list next-hop {
+          key "hop-index";
+          description
+            "An entry in a next-hop list.  Modules for address
+             families MUST augment this list with a leaf containing a
+             next-hop address of that address family.";
+          leaf hop-index {
+            type uint8;
+            description
+              "The value of the index for a hop.";
+          }
+          leaf outgoing-interface {
+            type if:interface-ref;
+            description
+              "This is a whole interface as the next hop.";
+          }
+          choice flow-type {
+            description
+              "These are the flow type next hop choices.";
+            case ip {
+              choice operation-type {
+                description
+                  "These are the next hop choices.";
+                case ip-forwarding {
+                  leaf next-hop-address {
+                    type inet:ip-address-no-zone;
+                    description
+                      "This is an IP address as a next hop.";
+                  }
+                }
+                case mpls-over-ip-encapsulation {
+                  uses ip-header;
+                }
+              }
+            }
+            case mpls {
+              uses rt-types:mpls-label-stack;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  container detnet {
+    description
+      "The top level DetNet container. This contains
+       applications, service sub-layers and forwarding sub-layers
+       as well as the traffic profiles.";
+    list traffic-profile {
+      key "profile-name";
+      description
+        "A traffic profile.";
+      leaf profile-name {
+        type string;
+        description
+          "An Aggregation group ID. Zero means the service is not
+           part of a group.";
+      }
+      container traffic-requirements {
+        description
+          "This defines the attributes of the App-flow
+           regarding bandwidth, latency, latency variation, loss, and
+           misordering tolerance.";
+        reference
+          "RFC 9016 Section 4.2";
+        leaf min-bandwidth {
+          type uint64;
+          units "bps";
+          description
+            "This is the minimum bandwidth that has to be
+             guaranteed for the DetNet service.  MinBandwidth is
+             specified in octets per second.";
+        }
+        leaf max-latency {
+          type uint32;
+          units "nanoseconds";
+          description
+            "This is the maximum latency from Ingress to
+             Egress(es) for a single packet of the DetNet flow.
+             MaxLatency is specified as an integer number of
+             nanoseconds.";
+        }
+        leaf max-latency-variation {
+          type uint32;
+          units "nanoseconds";
+          description
+            "This is the difference between the
+             minimum and the maximum end-to-end one-way latency.
+             MaxLatencyVariation is specified as an integer number of
+             nanoseconds.";
+        }
+        leaf max-loss {
+          type uint32;
+          description
+            "This defines the maximum Packet Loss Ratio (PLR)
+             parameter for the DetNet service between the Ingress and
+             Egress(es) of the DetNet domain.";
+        }
+        leaf max-consecutive-loss-tolerance {
+          type uint32;
+          units "packets";
+          description
+            "Some applications have special loss requirement, such
+             as MaxConsecutiveLossTolerance.  The maximum consecutive
+             loss tolerance parameter describes the maximum number of
+             consecutive packets whose loss can be tolerated.  The
+             maximum consecutive loss tolerance can be measured for
+             example based on sequence number.";
+        }
+        leaf max-misordering {
+          type uint32;
+          units "packets";
+          description
+            "This describes the tolerable maximum number
+             of packets that can be received out of order.  The
+             maximum allowed misordering can be measured for example
+             based on sequence number.  The value zero for the
+             maximum allowed misordering indicates that in order
+             delivery is required, misordering cannot be tolerated.";
+        }
+      }
+      container flow-spec {
+        description
+          "Flow-specification specifies how the Source transmits
+           packets for the flow.  This is the promise/request of the
+           Source to the network.  The network uses this flow
+           specification to allocate resources and adjust queue
+           parameters in network nodes.";
+        reference
+          "RFC 9016 Section 5.5";
+        leaf interval {
+          type uint32;
+          units "nanoseconds";
+          description
+            "The period of time in which the traffic
+             specification cannot be exceeded.";
+        }
+        leaf max-pkts-per-interval {
+          type uint32;
+          description
+            "The maximum number of packets that the
+             source will transmit in one interval.";
+        }
+        leaf max-payload-size {
+          type uint32;
+          description
+            "The maximum payload size that the source
+             will transmit.";
+        }
+        leaf min-payload-size {
+          type uint32;
+          description
+            "The minimum payload size that the source
+             will transmit.";
+        }
+        leaf min-pkts-per-interval {
+          type uint32;
+          description
+            "The minimum number of packets that the
+             source will transmit in one interval.";
+        }
+      }
+      leaf-list member-apps {
+        type app-flow-ref;
+        config false;
+        description
+          "Applications attached to this profile.";
+      }
+      leaf-list member-services {
+        type service-sub-layer-ref;
+        config false;
+        description
+          "Services attached to this profile.";
+      }
+      leaf-list member-fwd-sublayers {
+        type forwarding-sub-layer-ref;
+        config false;
+        description
+          "Forwarding sub-layer attached to this profile.";
+      }
+    }
+    container app-flows {
+      description
+        "The DetNet app-flow configuration.";
+      reference
+        "RFC 9016 Section 4.1";
+      list app-flow {
+        key "name";
+        description
+          "A unique (management) identifier of the App-flow.";
+        leaf name {
+          type string;
+          description
+            "A unique (management) identifier of the App-flow.";
+          reference
+            "RFC 9016
+             Sections 4.1, 5.1";
+        }
+        leaf app-flow-bidir-congruent {
+          type boolean;
+          default false;
+          description
+            "Defines the data path requirement of the App-flow
+             whether it must share the same data path and physical
+             path for both directions through the network, e.g., to
+             provide congruent paths in the two directions.";
+          reference
+            "RFC 9016 
+             Section 4.2";
+        }
+        leaf outgoing-service {
+          type service-sub-layer-ref;
+          config false;
+          description
+            "Binding to this applications outgoing
+             service.";
+        }
+        leaf incoming-service {
+          type service-sub-layer-ref;
+          config false;
+          description
+            "Binding to this applications incoming service.";
+        }
+        leaf traffic-profile {
+          type traffic-profile-ref;
+          description
+            "The Traffic Profile for this group.";
+        }
+        container ingress {
+          description
+            "Ingress DetNet application flows or a compound flow.";
+          leaf name {
+            type string;
+            description
+              "Ingress DetNet application.";
+          }
+          leaf app-flow-status {
+            type identityref {
+              base app-status;
+            }
+            config false;
+            description
+              "Status of ingress application flow.";
+            reference
+              "RFC 9016 Sections
+               4.1, 5.8";
+          }
+          leaf interface {
+            type if:interface-ref;
+            description
+            "Interface is used for any service type where a whole
+            interface is mapped to the applications. It may be 
+            further filtered by type.";
+          }
+          uses data-flow-spec;
+        } //End of app-ingress
+        container egress {
+          description
+            "Route's next-hop attribute.";
+          leaf name {
+            type string;
+            description
+              "Egress DetNet application.";
+          }
+          choice application-type {
+            description
+              "This is the application type choices.";
+            container ethernet {
+              description
+                "This is TSN unaware traffic that maps to an 
+                interface.";
+              leaf interface {
+                type if:interface-ref;
+                description
+                  "This is an Ethernet or TSN interfaces.";
+              }
+            }
+            container ip-mpls {
+              description
+                "This is IP or MPLS DetNet application types.";
+              uses detnet-app-next-hop-content;
+            }
+          }
+        }
+      }
+    }
+    container service-sub-layer {
+      description
+        "The DetNet service sub-layer configuration.";
+      list service-sub-layer-list {
+        key "name";
+        description
+          "Services are indexed by name.";
+        leaf name {
+          type string;
+          description
+            "The name of the DetNet service sub-layer.";
+        }
+        leaf service-rank {
+          type uint8;
+          description
+            "The DetNet rank for this service.";
+          reference
+            "RFC 9016 Section 5.7.";
+        }
+        leaf traffic-profile {
+          type traffic-profile-ref;
+          description
+            "The Traffic Profile for this service.";
+        }
+        container service-protection {
+          description
+            "This is the service protection type an sequence number 
+             options.";
+          leaf service-protection-type {
+            type service-protection-type;
+            description
+              "The DetNet service protection type such as PRF, PEF,
+               PEOF,PERF, and PEORF.";
+            reference
+              "RFC 8938 Section 4.3";
+          }
+          leaf sequence-number-length {
+            type sequence-number-field;
+            description
+              "Sequence number field length can be one of 0 (none),
+               16-bits or 28-bits.";
+          }
+        }
+        leaf service-operation-type {
+          type service-operation-type;
+          description
+            "This is the service operation type for this service 
+             sub-layer;"; 
+        }
+        container incoming-type {
+          description
+            "The DetNet service sub-layer incoming configuration.";
+          choice incoming-type {
+            mandatory true;
+            description
+              "A service sub-layer may have App flows or other
+               service sub-layers.";
+            container app-flow {
+              description
+                "This service sub-layer is related to the app-flows
+                 of the upper layer and provide ingress proxy or
+                 ingress aggregation at the ingress node.";
+              uses app-flows-group;
+            }
+            container service-aggregation {
+              description
+                "This service sub-layer is related to the service
+                 sub-layer of the upper layer and provide
+                 service-to-service aggregation at the ingress node
+                 or relay node.";
+              uses service-sub-layer-group;
+            }
+            container forwarding-aggregation {
+              description
+                "This service sub-layer is related to the forwarding
+                 sub-layer of the upper layer and provide
+                 forwarding-to-service aggregation at the ingress
+                 node or relay node.";
+              uses forwarding-sub-layer-group;
+            }
+            container service-id {
+              description
+                "This service sub-layer is related to the service or
+                 forwarding sub-layer of the lower layer and provide
+                 DetNet service relay or termination at the relay
+                 node or egress node.";
+              uses detnet-flow-spec;
+            }
+          }
+        }
+        container outgoing-type {
+          description
+            "The DetNet service sub-layer outgoing configuration.";
+          choice outgoing-type {
+            mandatory true;
+            description
+              "The out-going type may be a forwarding Sub-layer or a
+               service sub-layer or ? types need to be named.";
+            container forwarding-sub-layer {
+              description
+                "This service sub-layer is sent to the forwarding
+                 sub-layers of the lower layer for DetNet service
+                 forwarding or service-to-forwarding aggregation at
+                 the ingress node or relay node.  When the operation
+                 type is service-initiation, The service sub-layer
+                 encapsulates the DetNet Control-Word and services
+                 label, which are for individual DetNet flow when the
+                 incoming type is app-flow and for aggregated DetNet
+                 flow when the incoming type is service or
+                 forwarding.  The service sub-layer swaps the service
+                 label when the operation type is service-relay.";
+              list service-outgoing-list {
+                key "service-outgoing-index";
+                description
+                  "List of the outgoing service
+                   that separately for each node
+                   where services will be eliminated.";
+                leaf service-outgoing-index {
+                  type uint8;
+                  description
+                    "This index allows a list of multiple outgoing 
+                     forwarding sub-layers";
+                }
+                uses detnet-header;
+                uses forwarding-sub-layer-group; 
+              }
+            }
+            container service-sub-layer {
+              description
+                "This service sub-layer is sent to the service
+                 sub-layers of the lower layer for service-to-service
+                 aggregation at the ingress node or relay node.  The
+                 service sub-layer encapsulates the DetNet
+                 Control-Word and S-label when the operation type is
+                 service-initiation, and swaps the S-label when the
+                 operation type is service-relay.";
+              leaf aggregation-service-sub-layer {
+                type service-sub-layer-ref;
+                description
+                  "reference point of the service-sub-layer
+                   at which this service will be aggregated.";
+              }
+              container service-label {
+                description
+                  "This is the MPLS service sub-layer label.";
+                uses rt-types:mpls-label-stack;
+              }
+            }
+            container app-flow {
+              description
+                "This service sub-layer is sent to the app-flow of
+                 the upper layer for egress proxy at the egress node,
+                 and decapsulates the DetNet Control-Word and S-label
+                 for individual DetNet service.  This outgoing type
+                 only can be chosen when the operation type is
+                 service-termination.";
+              uses app-flows-group;
+            }
+            container service-disaggregation {
+              description
+                "This service sub-layer is sent to the service
+                 sub-layer of the upper layer for service-to-service
+                 disaggregation at the relay node or egress node, and
+                 decapsulates the DetNet Control-Word and A-label for
+                 aggregated DetNet service.  This outgoing type only
+                 can be chosen when the operation type is
+                 service-termination.";
+              uses service-sub-layer-group;
+            }
+            container forwarding-disaggregation {
+              description
+                "This service sub-layer is sent to the forwarding
+                 sub-layer of the upper layer for
+                 forwarding-to-service disaggregation at the relay
+                 node or egress node, and decapsulates the DetNet
+                 Control-Word and A-label for aggregated DetNet
+                 service.  This outgoing type only can be chosen when
+                 the operation type is service-termination.";
+              uses forwarding-sub-layer-group;
+            }
+          }
+        }
+      }
+    }
+    container forwarding-sub-layer {
+      description
+        "The DetNet forwarding sub-layer configuration.";
+      list forwarding-sub-layer-list {
+        key "name";
+        description
+          "The List is one or more DetNet Traffic types.";
+        leaf name {
+          type string;
+          description
+            "The name of the DetNet forwarding sub-layer.";
+        }
+        leaf traffic-profile {
+          type traffic-profile-ref;
+          description
+            "The Traffic Profile for this group.";
+        }
+        leaf forwarding-operation-type {
+          type forwarding-operations-type;
+          description
+            "This is the forwarding operation types 
+             impose-and-forward, pop-and-forward, 
+             pop-impose-and-forward, forward, pop-and-lookup.";
+        }
+        container incoming-type {
+          description
+            "The DetNet forwarding sub-layer incoming 
+             configuration.";
+          choice incoming-type {
+            mandatory true;
+            description
+              "Cases of incoming types.";
+            container service-sub-layer {
+              description
+                "This forwarding sub-layer is related to the service
+                 sub-layers of the upper layer and provide DetNet
+                 forwarding or service-to-forwarding aggregation at
+                 the ingress node or relay node.";
+              uses service-sub-layer-group;
+            }
+            container forwarding-aggregation {
+              description
+                "This forwarding sub-layer is related to the
+                 forwarding sub-layer of the upper layer and provide
+                 forwarding-to-forwarding aggregation at the ingress
+                 node or relay node or transit node.";
+              uses forwarding-sub-layer-group;
+            }
+            container forwarding-id  {
+              description
+                "This forwarding sub-layer is related to all of the
+                 lower layer and provide DetNet forwarding swap or
+                 termination at the transit node or relay node or
+                 egress node.";
+              leaf interface {
+                type if:interface-ref;
+                description
+                  "This is the interface associated with the
+                   forwarding sub-layer.";
+              }
+              uses detnet-flow-spec;
+            }
+          }
+        }
+        container outgoing-type {
+          description
+            "The DetNet forwarding sub-layer outbound
+             configuration.";
+          choice outgoing-type {
+            mandatory true;
+            description
+              "This is when a service connected directly to an
+              interface with no forwarding sub-layer."; 
+            container
+              interface {
+              description
+                "This forwarding sub-layer is sent to the interface
+                 for send to next-hop at the ingress node or relay
+                 node or transit node.";
+              uses detnet-forwarding-next-hop-content;
+            }
+            container service-aggregation {
+              description
+                "This forwarding sub-layer is sent to the service
+                 sub-layers of the lower layer for
+                 forwarding-to-service aggregation at the ingress
+                 node or relay node.";
+              leaf aggregation-service-sub-layer {
+                type service-sub-layer-ref;
+                description
+                  "This is reference to the service sub-layer.";
+              }
+              container optional-forwarding-label {
+                description 
+                  "This is the optional forwarding label for service 
+                   aggregation.";
+                uses rt-types:mpls-label-stack;
+              }
+            }
+            container forwarding-sub-layer {
+              description
+                "This forwarding sub-layer is sent to the forwarding
+                 sub-layers of the lower layer for
+                 forwarding-to-forwarding aggregation at the ingress
+                 node or relay node or transit node.";
+              leaf aggregation-forwarding-sub-layer {
+                type forwarding-sub-layer-ref;
+                description
+                  "This is reference to the forwarding sub-layer.";
+              }
+              container forwarding-label {
+                description
+                  "This is the forwarding label for forwarding
+                   sub-layer aggregation.";
+                uses rt-types:mpls-label-stack;
+              }
+            }
+            container service-sub-layer {
+              description
+                "This forwarding sub-layer is sent to the service
+                 sub-layer of the upper layer and decapsulate the
+                 F-label for DetNet service or service-to-forwarding
+                 disaggregation at the relay node or egress node.
+                 This outgoing type only can be chosen when the
+                 operation type is pop-and-lookup.";
+              uses service-sub-layer-group;
+            }
+            container forwarding-disaggregation {
+              description
+                "This forwarding sub-layer is sent to the forwarding
+                 sub-layer of the upper layer and decapsulate the
+                 F-label for forwarding-to-forwarding disaggregation
+                 at the transit node or relay node or egress node.
+                 This outgoing type only can be chosen when the
+                 operation type is pop-and-lookup.";
+              uses forwarding-sub-layer-group;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+]]></sourcecode>
+    </section>
+    <section anchor="IANA" toc="include" numbered="true" removeInRFC="false" pn="section-10">
+      <name>IANA Considerations</name>
+      <t>This document registers a URI in the "IETF XML Registry"
+   <xref target="RFC3688"/>.  Following the format in <xref target="RFC3688"/>,
+   the following registration is requested to be made:
+      </t>
+      <dl newline="false" spacing="compact" indent="3" pn="section-10-2">
+        <dt pn="section-10-2.1">ID:</dt>
+        <dd pn="section-10-2.2">yang:ietf-detnet</dd>
+        <dt pn="section-10-2.3">URI:</dt>
+        <dd pn="section-10-2.4">urn:ietf:params:xml:ns:yang:ietf-detnet</dd>
+        <dt pn="section-10-2.5">Registrant Contact:</dt>
+        <dd pn="section-10-2.6">The IESG.</dd>
+        <dt pn="section-10-2.7">XML:</dt>
+        <dd pn="section-10-2.8">N/A, the requested URI is an XML namespace.</dd>
+      </dl>
+      <t indent="0" pn="section-10-5">This document registers YANG modules in the "YANG Module Names"
+      registry <xref target="RFC6020" format="default" sectionFormat="of" derivedContent="RFC6020"/>.
+      </t>
+      <dl newline="false" spacing="compact" indent="3" pn="section-10-6">
+        <dt pn="section-10-6.1">Name:</dt>
+        <dd pn="section-10-6.2">ietf-detnet</dd>
+        <dt pn="section-10-6.3">Maintained by IANA:</dt>
+        <dd pn="section-10-6.4">N</dd>
+        <dt pn="section-10-6.5">Namespace:</dt>
+        <dd pn="section-10-6.6">urn:ietf:params:xml:ns:yang:ietf-detnet</dd>
+        <dt pn="section-10-6.7">Prefix:</dt>
+        <dd pn="section-10-6.8">dnet</dd>
+        <dt pn="section-10-6.9">Reference:</dt>
+        <dd pn="section-10-6.10">This RFC when published.</dd>
+      </dl>
+    </section>
+    <section anchor="Security" numbered="true" toc="default">
+      <name>Security Considerations</name>
+      <t> Security considerations for DetNet are covered in the DetNet Archtiecture 
+	      <xref target="RFC8655"/>.
+      </t>
+      <t>The YANG modules specified in this document define a schema for
+       data that is designed to be accessed via network
+       management protocols, such as NETCONF <xref target="RFC6241"/> or
+       RESTCONF <xref target="RFC8040"/>. The lowest NETCONF layer is the secure transport
+       layer, and the mandatory-to-implement secure transport is Secure Shell (SSH)
+       <xref target="RFC6242"/>. The lowest RESTCONF layer is HTTPS, and the
+       mandatory-to-implement secure transport is TLS <xref target="RFC8446"/>.
+      </t>
+      <t>The Network Configuration Access Control Model (NACM) <xref target="RFC8341"/>
+      provides the
+      means to restrict access for particular NETCONF or RESTCONF users to a
+      preconfigured subset of all available NETCONF or RESTCONF protocol
+      operations and content.</t>
+      <t>There are a number of data nodes defined in the modules
+      that are writable/creatable/deletable (i.e., config true, which is the default).
+      These data nodes may be considered sensitive or vulnerable in some network
+      environments. Write operations (e.g., edit-config) to these data nodes without
+      proper protection can break or incorrectly connect DetNet flows. 
+      </t>
+    </section>
+    <section anchor="Acknowledgments" numbered="true" toc="default">
+      <name>Acknowledgments</name>
+      <t>  The authors would like to thank Tom Petch for his detailed comments. 
+      </t>
+    </section>
+  </middle>
+  <back>
+    <references>
+      <name>References</name>
+      <references>
+        <name>Normative References</name>
+        <reference anchor="RFC2119" target="https://www.rfc-editor.org/info/rfc2119" xml:base="https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml">
+          <front>
+            <title>Key words for use in RFCs to Indicate Requirement Levels</title>
+            <author initials="S." surname="Bradner" fullname="S. Bradner">
+              <organization/>
+            </author>
+            <date year="1997" month="March"/>
+            <abstract>
+              <t>In many standards track documents several words are used to signify the requirements in the specification.  These words are often capitalized. This document defines these words as they should be interpreted in IETF documents.  This document specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="BCP" value="14"/>
+          <seriesInfo name="RFC" value="2119"/>
+          <seriesInfo name="DOI" value="10.17487/RFC2119"/>
+        </reference>
+        <?rfc include="reference.RFC.6991.xml"?>
+        <reference anchor="RFC3688" target="https://www.rfc-editor.org/info/rfc3688" quoteTitle="true" derivedAnchor="RFC3688">
+          <front>
+            <title>The IETF XML Registry</title>
+            <author initials="M." surname="Mealling" fullname="M. Mealling">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date year="2004" month="January"/>
+            <abstract>
+              <t indent="0">This document describes an IANA maintained registry for IETF standards which use Extensible Markup Language (XML) related items such as Namespaces, Document Type Declarations (DTDs), Schemas, and Resource Description Framework (RDF) Schemas.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="BCP" value="81"/>
+          <seriesInfo name="RFC" value="3688"/>
+          <seriesInfo name="DOI" value="10.17487/RFC3688"/>
+        </reference>
+        <reference anchor="RFC6020" target="https://www.rfc-editor.org/info/rfc6020" quoteTitle="true" derivedAnchor="RFC6020">
+          <front>
+            <title>YANG - A Data Modeling Language for the Network Configuration Protocol (NETCONF)</title>
+            <author initials="M." surname="Bjorklund" fullname="M. Bjorklund" role="editor">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date year="2010" month="October"/>
+            <abstract>
+              <t indent="0">YANG is a data modeling language used to model configuration and state data manipulated by the Network Configuration Protocol (NETCONF), NETCONF remote procedure calls, and NETCONF notifications. [STANDARDS-TRACK]</t>
+            </abstract>
+          </front>
+          <seriesInfo name="RFC" value="6020"/>
+          <seriesInfo name="DOI" value="10.17487/RFC6020"/>
+        </reference>
+        <reference anchor="RFC7950" target="https://www.rfc-editor.org/info/rfc7950" xml:base="https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7950.xml">
+          <front>
+            <title>The YANG 1.1 Data Modeling Language</title>
+            <author initials="M." surname="Bjorklund" fullname="M. Bjorklund" role="editor">
+              <organization/>
+            </author>
+            <date year="2016" month="August"/>
+            <abstract>
+              <t>YANG is a data modeling language used to model configuration data, state data, Remote Procedure Calls, and notifications for network management protocols.  This document describes the syntax and semantics of version 1.1 of the YANG language.  YANG version 1.1 is a maintenance release of the YANG language, addressing ambiguities and defects in the original specification.  There are a small number of backward incompatibilities from YANG version 1.  This document also specifies the YANG mappings to the Network Configuration Protocol (NETCONF).</t>
+            </abstract>
+          </front>
+          <seriesInfo name="RFC" value="7950"/>
+          <seriesInfo name="DOI" value="10.17487/RFC7950"/>
+        </reference>
+        <reference anchor="RFC8655" target="https://www.rfc-editor.org/info/rfc8655" xml:base="https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8655.xml">
+          <front>
+            <title>Deterministic Networking Architecture</title>
+            <author initials="N." surname="Finn" fullname="N. Finn">
+              <organization/>
+            </author>
+            <author initials="P." surname="Thubert" fullname="P. Thubert">
+              <organization/>
+            </author>
+            <author initials="B." surname="Varga" fullname="B. Varga">
+              <organization/>
+            </author>
+            <author initials="J." surname="Farkas" fullname="J. Farkas">
+              <organization/>
+            </author>
+            <date year="2019" month="October"/>
+            <abstract>
+              <t>This document provides the overall architecture for Deterministic Networking (DetNet), which provides a capability to carry specified unicast or multicast data flows for real-time applications with extremely low data loss rates and bounded latency within a network domain.  Techniques used include 1) reserving data-plane resources for individual (or aggregated) DetNet flows in some or all of the intermediate nodes along the path of the flow, 2) providing explicit routes for DetNet flows that do not immediately change with the network topology, and 3) distributing data from DetNet flow packets over time and/or space to ensure delivery of each packet's data in spite of the loss of a path.  DetNet operates at the IP layer and delivers service over lower-layer technologies such as MPLS and Time- Sensitive Networking (TSN) as defined by IEEE 802.1.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="RFC" value="8655"/>
+          <seriesInfo name="DOI" value="10.17487/RFC8655"/>
+        </reference>
+      <?rfc include="reference.RFC.6241.xml"?>
+      <?rfc include="reference.RFC.6242.xml"?>
+      <?rfc include="reference.RFC.8341.xml"?>
+      <?rfc include="reference.RFC.8446.xml"?>
+      <?rfc include="reference.RFC.8040.xml"?>
+      <?rfc include="reference.RFC.8174.xml"?>
+      <?rfc include="reference.RFC.8936.xml"?>
+      <?rfc include="reference.RFC.8340.xml"?>
+  
+      </references>
+      <references>
+        <name>Informative References</name>
+        <?rfc include="reference.RFC.9016.xml"?>
+      </references>
+    </references>
+    <section numbered="true" toc="default">
+       <name>DetNet Configuration YANG Tree</name>
+       <t> This is the full YANG tree as described in <xref target="RFC8340"/>.. 
+       </t>
+      <artwork name="" type="" align="left" alt=""><![CDATA[
+module: ietf-detnet
+  +--rw detnet
+     +--rw traffic-profile* [profile-name]
+     |  +--rw profile-name            string
+     |  +--rw traffic-requirements
+     |  |  +--rw min-bandwidth?                    uint64
+     |  |  +--rw max-latency?                      uint32
+     |  |  +--rw max-latency-variation?            uint32
+     |  |  +--rw max-loss?                         uint32
+     |  |  +--rw max-consecutive-loss-tolerance?   uint32
+     |  |  +--rw max-misordering?                  uint32
+     |  +--rw flow-spec
+     |  |  +--rw interval?                uint32
+     |  |  +--rw max-pkts-per-interval?   uint32
+     |  |  +--rw max-payload-size?        uint32
+     |  |  +--rw min-payload-size?        uint32
+     |  |  +--rw min-pkts-per-interval?   uint32
+     |  +--ro member-apps*            app-flow-ref
+     |  +--ro member-services*        service-sub-layer-ref
+     |  +--ro member-fwd-sublayers*   forwarding-sub-layer-ref
+     +--rw app-flows
+     |  +--rw app-flow* [name]
+     |     +--rw name                        string
+     |     +--rw app-flow-bidir-congruent?   boolean
+     |     +--ro outgoing-service?           service-sub-layer-ref
+     |     +--ro incoming-service?           service-sub-layer-ref
+     |     +--rw traffic-profile?            traffic-profile-ref
+     |     +--rw ingress
+     |     |  +--rw name?                  string
+     |     |  +--ro app-flow-status?       identityref
+     |     |  +--rw interface?             if:interface-ref
+     |     |  +--rw (data-flow-type)?
+     |     |     +--:(tsn-app-flow)
+     |     |     |  +--rw tsn-app-flow
+     |     |     |     +--rw source-mac-address?
+     |     |     |     |       yang:mac-address
+     |     |     |     +--rw destination-mac-address?
+     |     |     |     |       yang:mac-address
+     |     |     |     +--rw ethertype?
+     |     |     |     |       ethertypes:ethertype
+     |     |     |     +--rw vlan-id?
+     |     |     |     |       dot1q-types:vlanid
+     |     |     |     +--rw pcp?
+     |     |     |             dot1q-types:priority-type
+     |     |     +--:(ip-app-flow)
+     |     |     |  +--rw ip-app-flow
+     |     |     |     +--rw src-ip-prefix?          inet:ip-prefix
+     |     |     |     +--rw dest-ip-prefix?         inet:ip-prefix
+     |     |     |     +--rw protocol-next-header?   uint8
+     |     |     |     +--rw dscp?                   inet:dscp
+     |     |     |     +--rw flow-label?
+     |     |     |     |       inet:ipv6-flow-label
+     |     |     |     +--rw source-port
+     |     |     |     |  +--rw (port-range-or-operator)?
+     |     |     |     |     +--:(range)
+     |     |     |     |     |  +--rw lower-port    inet:port-number
+     |     |     |     |     |  +--rw upper-port    inet:port-number
+     |     |     |     |     +--:(operator)
+     |     |     |     |        +--rw operator?     operator
+     |     |     |     |        +--rw port          inet:port-number
+     |     |     |     +--rw destination-port
+     |     |     |     |  +--rw (port-range-or-operator)?
+     |     |     |     |     +--:(range)
+     |     |     |     |     |  +--rw lower-port    inet:port-number
+     |     |     |     |     |  +--rw upper-port    inet:port-number
+     |     |     |     |     +--:(operator)
+     |     |     |     |        +--rw operator?     operator
+     |     |     |     |        +--rw port          inet:port-number
+     |     |     |     +--rw ipsec-spi?              ipsec-spi
+     |     |     +--:(mpls-app-flow)
+     |     |        +--rw mpls-app-flow
+     |     |           +--rw (label-space)?
+     |     |              +--:(context-label-space)
+     |     |              |  +--rw mpls-label-stack
+     |     |              |     +--rw entry* [id]
+     |     |              |        +--rw id               uint8
+     |     |              |        +--rw label?
+     |     |              |        |       rt-types:mpls-label
+     |     |              |        +--rw ttl?             uint8
+     |     |              |        +--rw traffic-class?   uint8
+     |     |              +--:(platform-label-space)
+     |     |                 +--rw label?
+     |     |                         rt-types:mpls-label
+     |     +--rw egress
+     |        +--rw name?             string
+     |        +--rw (application-type)?
+     |           +--:(ethernet)
+     |           |  +--rw ethernet
+     |           |     +--rw interface?   if:interface-ref
+     |           +--:(ip-mpls)
+     |              +--rw ip-mpls
+     |                 +--rw (next-hop-options)
+     |                    +--:(simple-next-hop)
+     |                    |  +--rw outgoing-interface?
+     |                    |  |       if:interface-ref
+     |                    |  +--rw (flow-type)?
+     |                    |     +--:(ip)
+     |                    |     |  +--rw next-hop-address?
+     |                    |     |          inet:ip-address
+     |                    |     +--:(mpls)
+     |                    |        +--rw mpls-label-stack
+     |                    |           +--rw entry* [id]
+     |                    |              +--rw id               uint8
+     |                    |              +--rw label?
+     |                    |              |       rt-types:mpls-label
+     |                    |              +--rw ttl?             uint8
+     |                    |              +--rw traffic-class?   uint8
+     |                    +--:(next-hop-list)
+     |                       +--rw next-hop* [hop-index]
+     |                          +--rw hop-index                 uint8
+     |                          +--rw outgoing-interface?
+     |                          |       if:interface-ref
+     |                          +--rw (flow-type)?
+     |                             +--:(ip)
+     |                             |  +--rw next-hop-address?
+     |                             |          inet:ip-address
+     |                             +--:(mpls)
+     |                                +--rw mpls-label-stack
+     |                                   +--rw entry* [id]
+     |                                      +--rw id
+     |                                      |       uint8
+     |                                      +--rw label?
+     |                                      |       rt-types:mpls-label
+     |                                      +--rw ttl?
+     |                                      |       uint8
+     |                                      +--rw traffic-class?
+     |                                              uint8
+     +--rw service-sub-layer
+     |  +--rw service-sub-layer-list* [name]
+     |     +--rw name                      string
+     |     +--rw service-rank?             uint8
+     |     +--rw traffic-profile?          traffic-profile-ref
+     |     +--rw service-protection
+     |     |  +--rw service-protection-type?   service-protection-type
+     |     |  +--rw sequence-number-length?    sequence-number-field
+     |     +--rw service-operation-type?   service-operation-type
+     |     +--rw incoming-type
+     |     |  +--rw (incoming-type)
+     |     |     +--:(app-flow)
+     |     |     |  +--rw app-flow
+     |     |     |     +--rw app-flow-list*   app-flow-ref
+     |     |     +--:(service-aggregation)
+     |     |     |  +--rw service-aggregation
+     |     |     |     +--rw service-sub-layer*
+     |     |     |             service-sub-layer-ref
+     |     |     +--:(forwarding-aggregation)
+     |     |     |  +--rw forwarding-aggregation
+     |     |     |     +--rw forwarding-sub-layer*
+     |     |     |             forwarding-sub-layer-ref
+     |     |     +--:(service-id)
+     |     |        +--rw service-id
+     |     |           +--rw (detnet-flow-type)?
+     |     |              +--:(ip-detnet-flow)
+     |     |              |  +--rw src-ip-prefix?
+     |     |              |  |       inet:ip-prefix
+     |     |              |  +--rw dest-ip-prefix?
+     |     |              |  |       inet:ip-prefix
+     |     |              |  +--rw protocol-next-header?     uint8
+     |     |              |  +--rw dscp?                     inet:dscp
+     |     |              |  +--rw flow-label?
+     |     |              |  |       inet:ipv6-flow-label
+     |     |              |  +--rw source-port
+     |     |              |  |  +--rw (port-range-or-operator)?
+     |     |              |  |     +--:(range)
+     |     |              |  |     |  +--rw lower-port
+     |     |              |  |     |  |       inet:port-number
+     |     |              |  |     |  +--rw upper-port
+     |     |              |  |     |          inet:port-number
+     |     |              |  |     +--:(operator)
+     |     |              |  |        +--rw operator?     operator
+     |     |              |  |        +--rw port
+     |     |              |  |                inet:port-number
+     |     |              |  +--rw destination-port
+     |     |              |  |  +--rw (port-range-or-operator)?
+     |     |              |  |     +--:(range)
+     |     |              |  |     |  +--rw lower-port
+     |     |              |  |     |  |       inet:port-number
+     |     |              |  |     |  +--rw upper-port
+     |     |              |  |     |          inet:port-number
+     |     |              |  |     +--:(operator)
+     |     |              |  |        +--rw operator?     operator
+     |     |              |  |        +--rw port
+     |     |              |  |                inet:port-number
+     |     |              |  +--rw ipsec-spi?                ipsec-spi
+     |     |              +--:(mpls-detnet-flow)
+     |     |                 +--rw (label-space)?
+     |     |                    +--:(context-label-space)
+     |     |                    |  +--rw mpls-label-stack
+     |     |                    |     +--rw entry* [id]
+     |     |                    |        +--rw id               uint8
+     |     |                    |        +--rw label?
+     |     |                    |        |       rt-types:mpls-label
+     |     |                    |        +--rw ttl?             uint8
+     |     |                    |        +--rw traffic-class?   uint8
+     |     |                    +--:(platform-label-space)
+     |     |                       +--rw label?
+     |     |                               rt-types:mpls-label
+     |     +--rw outgoing-type
+     |        +--rw (outgoing-type)
+     |           +--:(forwarding-sub-layer)
+     |           |  +--rw forwarding-sub-layer
+     |           |     +--rw service-outgoing-list*
+     |           |             [service-outgoing-index]
+     |           |        +--rw service-outgoing-index        uint8
+     |           |        +--rw (header-type)?
+     |           |        |  +--:(detnet-mpls-header)
+     |           |        |  |  +--rw mpls-label-stack
+     |           |        |  |     +--rw entry* [id]
+     |           |        |  |        +--rw id               uint8
+     |           |        |  |        +--rw label?
+     |           |        |  |        |       rt-types:mpls-label
+     |           |        |  |        +--rw ttl?             uint8
+     |           |        |  |        +--rw traffic-class?   uint8
+     |           |        |  +--:(detnet-ip-header)
+     |           |        |     +--rw src-ip-address?
+     |           |        |     |       inet:ip-address
+     |           |        |     +--rw dest-ip-address?
+     |           |        |     |       inet:ip-address
+     |           |        |     +--rw protocol-next-header?   uint8
+     |           |        |     +--rw dscp?
+     |           |        |     |       inet:dscp
+     |           |        |     +--rw flow-label?
+     |           |        |     |       inet:ipv6-flow-label
+     |           |        |     +--rw source-port?
+     |           |        |     |       inet:port-number
+     |           |        |     +--rw destination-port?
+     |           |        |             inet:port-number
+     |           |        +--rw forwarding-sub-layer*
+     |           |                forwarding-sub-layer-ref
+     |           +--:(service-sub-layer)
+     |           |  +--rw service-sub-layer
+     |           |     +--rw aggregation-service-sub-layer?
+     |           |     |       service-sub-layer-ref
+     |           |     +--rw service-label
+     |           |        +--rw mpls-label-stack
+     |           |           +--rw entry* [id]
+     |           |              +--rw id               uint8
+     |           |              +--rw label?
+     |           |              |       rt-types:mpls-label
+     |           |              +--rw ttl?             uint8
+     |           |              +--rw traffic-class?   uint8
+     |           +--:(app-flow)
+     |           |  +--rw app-flow
+     |           |     +--rw app-flow-list*   app-flow-ref
+     |           +--:(service-disaggregation)
+     |           |  +--rw service-disaggregation
+     |           |     +--rw service-sub-layer*
+     |           |             service-sub-layer-ref
+     |           +--:(forwarding-disaggregation)
+     |              +--rw forwarding-disaggregation
+     |                 +--rw forwarding-sub-layer*
+     |                         forwarding-sub-layer-ref
+     +--rw forwarding-sub-layer
+        +--rw forwarding-sub-layer-list* [name]
+           +--rw name                         string
+           +--rw traffic-profile?             traffic-profile-ref
+           +--rw forwarding-operation-type?
+           |       forwarding-operations-type
+           +--rw incoming-type
+           |  +--rw (incoming-type)
+           |     +--:(service-sub-layer)
+           |     |  +--rw service-sub-layer
+           |     |     +--rw service-sub-layer*
+           |     |             service-sub-layer-ref
+           |     +--:(forwarding-aggregation)
+           |     |  +--rw forwarding-aggregation
+           |     |     +--rw forwarding-sub-layer*
+           |     |             forwarding-sub-layer-ref
+           |     +--:(forwarding-id)
+           |        +--rw forwarding-id
+           |           +--rw interface?
+           |           |       if:interface-ref
+           |           +--rw (detnet-flow-type)?
+           |              +--:(ip-detnet-flow)
+           |              |  +--rw src-ip-prefix?
+           |              |  |       inet:ip-prefix
+           |              |  +--rw dest-ip-prefix?
+           |              |  |       inet:ip-prefix
+           |              |  +--rw protocol-next-header?     uint8
+           |              |  +--rw dscp?                     inet:dscp
+           |              |  +--rw flow-label?
+           |              |  |       inet:ipv6-flow-label
+           |              |  +--rw source-port
+           |              |  |  +--rw (port-range-or-operator)?
+           |              |  |     +--:(range)
+           |              |  |     |  +--rw lower-port
+           |              |  |     |  |       inet:port-number
+           |              |  |     |  +--rw upper-port
+           |              |  |     |          inet:port-number
+           |              |  |     +--:(operator)
+           |              |  |        +--rw operator?     operator
+           |              |  |        +--rw port
+           |              |  |                inet:port-number
+           |              |  +--rw destination-port
+           |              |  |  +--rw (port-range-or-operator)?
+           |              |  |     +--:(range)
+           |              |  |     |  +--rw lower-port
+           |              |  |     |  |       inet:port-number
+           |              |  |     |  +--rw upper-port
+           |              |  |     |          inet:port-number
+           |              |  |     +--:(operator)
+           |              |  |        +--rw operator?     operator
+           |              |  |        +--rw port
+           |              |  |                inet:port-number
+           |              |  +--rw ipsec-spi?                ipsec-spi
+           |              +--:(mpls-detnet-flow)
+           |                 +--rw (label-space)?
+           |                    +--:(context-label-space)
+           |                    |  +--rw mpls-label-stack
+           |                    |     +--rw entry* [id]
+           |                    |        +--rw id               uint8
+           |                    |        +--rw label?
+           |                    |        |       rt-types:mpls-label
+           |                    |        +--rw ttl?             uint8
+           |                    |        +--rw traffic-class?   uint8
+           |                    +--:(platform-label-space)
+           |                       +--rw label?
+           |                               rt-types:mpls-label
+           +--rw outgoing-type
+              +--rw (outgoing-type)
+                 +--:(interface)
+                 |  +--rw interface
+                 |     +--rw (next-hop-options)
+                 |        +--:(simple-next-hop)
+                 |        |  +--rw outgoing-interface?
+                 |        |  |       if:interface-ref
+                 |        |  +--rw (flow-type)?
+                 |        |     +--:(ip)
+                 |        |     |  +--rw (operation-type)?
+                 |        |     |     +--:(ip-forwarding)
+                 |        |     |     |  +--rw next-hop-address?
+                 |        |     |     |          inet:ip-address
+                 |        |     |     +--:(mpls-over-ip-encapsulation)
+                 |        |     |        +--rw src-ip-address?
+                 |        |     |        |       inet:ip-address
+                 |        |     |        +--rw dest-ip-address?
+                 |        |     |        |       inet:ip-address
+                 |        |     |        +--rw protocol-next-header?
+                 |        |     |        |       uint8
+                 |        |     |        +--rw dscp?
+                 |        |     |        |       inet:dscp
+                 |        |     |        +--rw flow-label?
+                 |        |     |        |       inet:ipv6-flow-label
+                 |        |     |        +--rw source-port?
+                 |        |     |        |       inet:port-number
+                 |        |     |        +--rw destination-port?
+                 |        |     |                inet:port-number
+                 |        |     +--:(mpls)
+                 |        |        +--rw mpls-label-stack
+                 |        |           +--rw entry* [id]
+                 |        |              +--rw id               uint8
+                 |        |              +--rw label?
+                 |        |              |       rt-types:mpls-label
+                 |        |              +--rw ttl?             uint8
+                 |        |              +--rw traffic-class?   uint8
+                 |        +--:(next-hop-list)
+                 |           +--rw next-hop* [hop-index]
+                 |              +--rw hop-index
+                 |              |       uint8
+                 |              +--rw outgoing-interface?
+                 |              |       if:interface-ref
+                 |              +--rw (flow-type)?
+                 |                 +--:(ip)
+                 |                 |  +--rw (operation-type)?
+                 |                 |     +--:(ip-forwarding)
+                 |                 |     |  +--rw next-hop-address?
+                 |                 |     |          inet:ip-address
+                 |                 |     +--:(mpls-over-ip-
+                 |                 |          encapsulation)
+                 |                 |        +--rw src-ip-address?
+                 |                 |        |       inet:ip-address
+                 |                 |        +--rw dest-ip-address?
+                 |                 |        |       inet:ip-address
+                 |                 |        +--rw protocol-next-header?
+                 |                 |        |       uint8
+                 |                 |        +--rw dscp?
+                 |                 |        |       inet:dscp
+                 |                 |        +--rw flow-label?
+                 |                 |        |       inet:ipv6-flow-label
+                 |                 |        +--rw source-port?
+                 |                 |        |       inet:port-number
+                 |                 |        +--rw destination-port?
+                 |                 |                inet:port-number
+                 |                 +--:(mpls)
+                 |                    +--rw mpls-label-stack
+                 |                       +--rw entry* [id]
+                 |                          +--rw id
+                 |                          |       uint8
+                 |                          +--rw label?
+                 |                          |       rt-types:mpls-label
+                 |                          +--rw ttl?
+                 |                          |       uint8
+                 |                          +--rw traffic-class?
+                 |                                  uint8
+                 +--:(service-aggregation)
+                 |  +--rw service-aggregation
+                 |     +--rw aggregation-service-sub-layer?
+                 |     |       service-sub-layer-ref
+                 |     +--rw optional-forwarding-label
+                 |        +--rw mpls-label-stack
+                 |           +--rw entry* [id]
+                 |              +--rw id               uint8
+                 |              +--rw label?
+                 |              |       rt-types:mpls-label
+                 |              +--rw ttl?             uint8
+                 |              +--rw traffic-class?   uint8
+                 +--:(forwarding-sub-layer)
+                 |  +--rw forwarding-sub-layer
+                 |     +--rw aggregation-forwarding-sub-layer?
+                 |     |       forwarding-sub-layer-ref
+                 |     +--rw forwarding-label
+                 |        +--rw mpls-label-stack
+                 |           +--rw entry* [id]
+                 |              +--rw id               uint8
+                 |              +--rw label?
+                 |              |       rt-types:mpls-label
+                 |              +--rw ttl?             uint8
+                 |              +--rw traffic-class?   uint8
+                 +--:(service-sub-layer)
+                 |  +--rw service-sub-layer
+                 |     +--rw service-sub-layer*
+                 |             service-sub-layer-ref
+                 +--:(forwarding-disaggregation)
+                    +--rw forwarding-disaggregation
+                       +--rw forwarding-sub-layer*
+                               forwarding-sub-layer-ref
+              ]]></artwork>
+    </section>
+    <section numbered="true" toc="default">
+      <name>Examples</name>
+      <t> The following examples are provided.  These examples are tested with Yanglint
+            and use operational output to exercise both config true and config false objects.
+                    
+    </t>
+    <t>
+         The following are examples of aggregation and disaggregation at various points in Detnet. Figures 
+         are provided in the PDF version of this document.
+    </t>
+    <section numbered="true" toc="default">
+        <name>Example A-1 JSON Configuration/Operational</name>
+        <t>
+                This illustrates simple aggregation. Ingress node 1 
+                aggregates App flows 0 and 1 into a service sub-layer of DetNet flow 1. 
+                Two ways of illustrating this follow, then the JSON operational data model
+                corresponding to the diagrams follows.
+        </t>
+
+                <figure anchor="case-a1">
+                <name>Case A-1 Example JSON Operational/Configuration</name>
+          <artset>
+            <artwork align="left" type="ascii-art" name="" alt=""><![CDATA[
+        
+Please consult the PDF or HTML versions for the Case A-1 Diagram.
+]]></artwork>
+        <artwork type="svg">
+<svg
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="210mm"
+   height="120mm"
+   viewBox="0 -65 210 110"
+   version="1.1"
+   >
+  <defs
+     id="defs201" />
+  <g
+     
+     transform="matrix(1,0,0,0.97931387,-3.1750001,-77.150385)">
+    <path
+       d="m 78.932864,66.471283 c 0,-0.457693 -0.276038,-0.828725 -0.616551,-0.828725 h -6.739296 c -0.34052,0 -0.616564,0.371032 -0.616564,0.828725 v 7.244984 c 0,0.457699 0.276044,0.828733 0.616564,0.828733 h 6.739296 c 0.340513,0 0.616551,-0.371034 0.616551,-0.828733 z"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 77.497526,66.137137 v 0.959894 h -1.664393 l -0.886453,2.153914 -0.904562,-2.153914 h -1.646302 v -0.959894 l -1.067381,1.217424 1.067381,1.217425 v -0.819418 h 1.175932 l 1.013106,2.36462 -1.013106,2.388029 h -1.175932 v -0.889646 l -1.067381,1.217424 1.067381,1.217425 v -0.913075 h 1.646302 l 0.904562,-2.200734 0.886453,2.200734 h 1.664393 V 74.0036 l 1.067381,-1.170605 -1.067381,-1.217424 v 0.889646 h -1.15784 l -1.031198,-2.388029 1.013107,-2.36462 h 1.175931 v 0.796008 l 1.067381,-1.194015 z"
+       stroke="#000000"
+       stroke-width="0.248847"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 47.411229,70.093778 H 70.942068"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="8.3851624"
+       y="67.142136"
+       transform="scale(0.86254171,1.1593642)">Source 1<tspan
+   font-size="2.70177px"
+   x="9.6277428"
+   y="70.412712"
+   >192.0.2.1</tspan><tspan
+   font-size="2.70177px"
+   x="44.797974"
+   y="67.142136"
+   >Ingress 1</tspan><tspan
+   font-size="2.70177px"
+   x="46.186546"
+   y="70.412712"
+   >192.0.2.2</tspan><tspan
+   font-size="2.70177px"
+   x="82.330742"
+   y="67.142136"
+   >Relay 1</tspan><tspan
+   font-size="2.70177px"
+   x="82.745392"
+   y="70.412712"
+   >192.0.2.3</tspan><tspan
+   font-size="2.70177px"
+   x="155.44701"
+   y="67.142136"
+   >Relay 2</tspan><tspan
+   font-size="2.70177px"
+   x="155.86082"
+   y="70.412712"
+   >192.0.2.6</tspan><tspan
+   font-size="2.70177px"
+   x="191.25833"
+   y="67.142136"
+   >Egress 1</tspan><tspan
+   font-size="2.70177px"
+   x="192.41724"
+   y="70.412712"
+   >192.0.2.77</tspan><tspan
+   font-size="2.70177px"
+   x="118.2251"
+   y="85.770157"
+   >Transit 2</tspan><tspan
+   font-size="2.70177px"
+   x="119.30182"
+   y="89.040741"
+   >192.0.2.5</tspan><tspan
+   font-size="2.70177px"
+   x="118.2251"
+   y="48.514111"
+   >Transit 1</tspan><tspan
+   font-size="2.70177px"
+   x="119.30182"
+   y="51.784679"
+   >192.0.2.4</tspan></text>
+    <path
+       d="m 110.4545,44.874615 c 0,-0.457693 -0.27604,-0.828726 -0.61655,-0.828726 h -6.73929 c -0.34053,0 -0.61657,0.371033 -0.61657,0.828726 v 7.244984 c 0,0.457699 0.27604,0.828733 0.61657,0.828733 h 6.73929 c 0.34051,0 0.61655,-0.371034 0.61655,-0.828733 z"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 108.9146,44.705327 v 0.939898 h -1.63618 l -0.87145,2.10904 -0.88922,-2.10904 h -1.6184 v -0.939898 l -1.0493,1.19207 1.0493,1.192071 v -0.802357 h 1.156 l 0.99593,2.315358 -0.99593,2.338294 h -1.156 v -0.871122 l -1.0493,1.192052 1.0493,1.192071 v -0.894052 h 1.6184 l 0.88922,-2.154886 0.87145,2.154886 h 1.63618 v 0.848205 l 1.04929,-1.146224 -1.04929,-1.192052 v 0.871122 h -1.13821 l -1.01372,-2.338294 0.99593,-2.315358 h 1.156 v 0.779421 l 1.04929,-1.169135 z"
+       stroke="#000000"
+       stroke-width="0.248847"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="225.28676"
+       y="67.142136"
+       transform="scale(0.86254171,1.1593642)">Destination 1<tspan
+   font-size="2.70177px"
+   x="228.97635"
+   y="70.412712"
+   >192.0.2.88</tspan></text>
+    <path
+       d="M 15.889594,70.093778 H 39.420433"
+       stroke="#000000"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 78.932864,70.035743 102.46371,48.49711"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 110.4545,48.49711 23.53084,21.538633"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 141.97613,70.093778 h 23.53085"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 173.49777,70.093778 h 23.53084"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 110.4545,91.592347 133.98534,70.093772"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 78.932864,70.093778 102.46371,91.592516"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="81.14061"
+       y="28.219326"
+       width="18.520494"
+       height="9.5618668"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.27518px"
+       
+       x="101.64459"
+       y="27.895308"
+       transform="scale(0.86254171,1.1593642)">MPLS<tspan
+   font-size="2.27518px"
+   x="98.782845"
+   y="30.597084"
+   >S</tspan><tspan
+   font-size="2.27518px"
+   x="100.31741"
+   y="30.597084"
+   >-</tspan><tspan
+   font-size="2.27518px"
+   x="101.10541"
+   y="30.597084"
+   >label 101</tspan></text>
+    <rect
+       x="81.14061"
+       y="37.946068"
+       width="18.520494"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.27518px"
+       
+       x="101.64544"
+       y="36.285027"
+       transform="scale(0.86254171,1.1593642)">MPLS<tspan
+   font-size="2.27518px"
+   x="97.559372"
+   y="38.986801"
+   >F</tspan><tspan
+   font-size="2.27518px"
+   x="98.969498"
+   y="38.986801"
+   >-</tspan><tspan
+   font-size="2.27518px"
+   x="99.757515"
+   y="38.986801"
+   >label 10001</tspan></text>
+    <rect
+       x="81.14061"
+       y="18.8223"
+       width="18.520494"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="99.11544"
+       y="19.647791"
+       transform="scale(0.86254171,1.1593642)">IP 192.0.2.1<tspan
+   font-size="2.70177px"
+   x="102.61922"
+   y="22.918352"
+   >192.0.2.88</tspan></text>
+    <rect
+       x="81.017952"
+       y="120.04636"
+       width="18.643147"
+       height="9.561883"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.27518px"
+       
+       x="101.50993"
+       y="107.24217"
+       transform="scale(0.86254171,1.1593642)">MPLS<tspan
+   font-size="2.27518px"
+   x="97.423851"
+   y="109.94393"
+   >F</tspan><tspan
+   font-size="2.27518px"
+   x="98.833969"
+   y="109.94393"
+   >-</tspan><tspan
+   font-size="2.27518px"
+   x="99.621994"
+   y="109.94393"
+   >label 10002</tspan></text>
+    <rect
+       x="81.017952"
+       y="101.41718"
+       width="18.643147"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="98.979935"
+       y="90.889305"
+       transform="scale(0.86254171,1.1593642)">IP 192.0.2.1<tspan
+   font-size="2.70177px"
+   x="102.4837"
+   y="94.159889"
+   >192.0.2.88</tspan></text>
+    <rect
+       x="112.66224"
+       y="28.219326"
+       width="18.520494"
+       height="9.5618668"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.27518px"
+       
+       x="138.18581"
+       y="27.895308"
+       transform="scale(0.86254171,1.1593642)">MPLS<tspan
+   font-size="2.27518px"
+   x="135.32407"
+   y="30.597084"
+   >S</tspan><tspan
+   font-size="2.27518px"
+   x="136.85863"
+   y="30.597084"
+   >-</tspan><tspan
+   font-size="2.27518px"
+   x="137.64664"
+   y="30.597084"
+   >label 101</tspan></text>
+    <rect
+       x="112.66224"
+       y="37.946068"
+       width="18.520494"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.27518px"
+       
+       x="138.18581"
+       y="36.285027"
+       transform="scale(0.86254171,1.1593642)">MPLS<tspan
+   font-size="2.27518px"
+   x="134.09975"
+   y="38.986801"
+   >F</tspan><tspan
+   font-size="2.27518px"
+   x="135.50986"
+   y="38.986801"
+   >-</tspan><tspan
+   font-size="2.27518px"
+   x="136.29788"
+   y="38.986801"
+   >label 10003</tspan></text>
+    <rect
+       x="112.66224"
+       y="18.8223"
+       width="18.520494"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="135.65608"
+       y="19.647791"
+       transform="scale(0.86254171,1.1593642)">IP 192.0.2.1<tspan
+   font-size="2.70177px"
+   x="139.15987"
+   y="22.918352"
+   >192.0.2.88</tspan></text>
+    <rect
+       x="112.90755"
+       y="120.04636"
+       width="18.520494"
+       height="9.561883"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.27518px"
+       
+       x="138.41759"
+       y="107.24217"
+       transform="scale(0.86254171,1.1593642)">MPLS<tspan
+   font-size="2.27518px"
+   x="134.33151"
+   y="109.94393"
+   >F</tspan><tspan
+   font-size="2.27518px"
+   x="135.74164"
+   y="109.94393"
+   >-</tspan><tspan
+   font-size="2.27518px"
+   x="136.52966"
+   y="109.94393"
+   >label 10004</tspan></text>
+    <rect
+       x="112.90755"
+       y="101.41718"
+       width="18.520494"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="135.88788"
+       y="90.889305"
+       transform="scale(0.86254171,1.1593642)">IP 192.0.2.1<tspan
+   font-size="2.70177px"
+   x="139.39165"
+   y="94.159889"
+   >192.0.2.88</tspan></text>
+    <rect
+       x="49.864277"
+       y="28.219326"
+       width="18.520494"
+       height="9.5618668"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.27518px"
+       
+       x="65.358055"
+       y="27.895308"
+       transform="scale(0.86254171,1.1593642)">MPLS<tspan
+   font-size="2.27518px"
+   x="62.4963"
+   y="30.597084"
+   >S</tspan><tspan
+   font-size="2.27518px"
+   x="64.030861"
+   y="30.597084"
+   >-</tspan><tspan
+   font-size="2.27518px"
+   x="64.818886"
+   y="30.597084"
+   >label 100</tspan></text>
+    <rect
+       x="49.864277"
+       y="37.946068"
+       width="18.520494"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.27518px"
+       
+       x="65.35891"
+       y="36.285027"
+       transform="scale(0.86254171,1.1593642)">MPLS<tspan
+   font-size="2.27518px"
+   x="61.272827"
+   y="38.986801"
+   >F</tspan><tspan
+   font-size="2.27518px"
+   x="62.682949"
+   y="38.986801"
+   >-</tspan><tspan
+   font-size="2.27518px"
+   x="63.470974"
+   y="38.986801"
+   >label 10000</tspan></text>
+    <rect
+       x="49.864277"
+       y="18.8223"
+       width="18.520494"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="62.828907"
+       y="19.647791"
+       transform="scale(0.86254171,1.1593642)">IP 192.0.2.1<tspan
+   font-size="2.70177px"
+   x="66.33268"
+   y="22.918352"
+   >192.0.2.88</tspan></text>
+    <rect
+       x="144.30653"
+       y="28.219326"
+       width="18.520494"
+       height="9.5618668"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.27518px"
+       
+       x="174.84889"
+       y="27.895308"
+       transform="scale(0.86254171,1.1593642)">MPLS<tspan
+   font-size="2.27518px"
+   x="171.98714"
+   y="30.597084"
+   >S</tspan><tspan
+   font-size="2.27518px"
+   x="173.5217"
+   y="30.597084"
+   >-</tspan><tspan
+   font-size="2.27518px"
+   x="174.30971"
+   y="30.597084"
+   >label 102</tspan></text>
+    <rect
+       x="144.30653"
+       y="37.946068"
+       width="18.520494"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.27518px"
+       
+       x="174.84746"
+       y="36.285027"
+       transform="scale(0.86254171,1.1593642)">MPLS<tspan
+   font-size="2.27518px"
+   x="170.7614"
+   y="38.986801"
+   >F</tspan><tspan
+   font-size="2.27518px"
+   x="172.17152"
+   y="38.986801"
+   >-</tspan><tspan
+   font-size="2.27518px"
+   x="172.95955"
+   y="38.986801"
+   >label 10005</tspan></text>
+    <rect
+       x="144.30653"
+       y="18.8223"
+       width="18.520494"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="172.32059"
+       y="19.647791"
+       transform="scale(0.86254171,1.1593642)">IP 192.0.2.1<tspan
+   font-size="2.70177px"
+   x="175.82437"
+   y="22.918352"
+   >192.0.2.88</tspan></text>
+    <rect
+       x="81.017952"
+       y="110.81422"
+       width="18.643147"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.27518px"
+       
+       x="101.50908"
+       y="99.136833"
+       transform="scale(0.86254171,1.1593642)">MPLS<tspan
+   font-size="2.27518px"
+   x="98.647324"
+   y="101.83861"
+   >S</tspan><tspan
+   font-size="2.27518px"
+   x="100.18188"
+   y="101.83861"
+   >-</tspan><tspan
+   font-size="2.27518px"
+   x="100.9699"
+   y="101.83861"
+   >label 101</tspan></text>
+    <rect
+       x="112.90755"
+       y="110.81422"
+       width="18.520494"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.27518px"
+       
+       x="138.41617"
+       y="99.136833"
+       transform="scale(0.86254171,1.1593642)">MPLS<tspan
+   font-size="2.27518px"
+   x="135.55441"
+   y="101.83861"
+   >S</tspan><tspan
+   font-size="2.27518px"
+   x="137.08899"
+   y="101.83861"
+   >-</tspan><tspan
+   font-size="2.27518px"
+   x="137.87701"
+   y="101.83861"
+   >label 101</tspan></text>
+    <path
+       d="m 38.810239,69.599198 c -0.211699,0 -0.383289,-0.922726 -0.383289,-2.060756 0,-1.138191 0.17159,-2.060749 0.383289,-2.060749 0.211697,0 0.383287,0.922558 0.383287,2.060749 0,1.13803 -0.17159,2.060756 -0.383287,2.060756 H 15.904925 c -0.211698,0 -0.383288,-0.922726 -0.383288,-2.060756 0,-1.138191 0.17159,-2.060749 0.383288,-2.060749 h 22.905314"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="28.520348"
+       y="59.463413"
+       transform="scale(0.86254171,1.1593642)">App-0</text>
+    <path
+       d="m 196.40308,69.928914 c -0.22077,0 -0.39862,-0.959482 -0.39862,-2.143178 0,-1.183697 0.17785,-2.143178 0.39862,-2.143178 0.21955,0 0.39863,0.959481 0.39863,2.143178 0,1.183696 -0.17908,2.143178 -0.39863,2.143178 h -22.87465 c -0.21954,0 -0.39861,-0.959482 -0.39861,-2.143178 0,-1.183697 0.17907,-2.143178 0.39861,-2.143178 h 22.87465"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="211.12234"
+       y="59.747807"
+       transform="scale(0.86254171,1.1593642)">App-0</text>
+    <path
+       d="m 164.45217,74.707546 c -0.4575,0 -0.8279,-1.992328 -0.8279,-4.450062 0,-2.457903 0.3704,-4.450237 0.8279,-4.450237 0.45749,0 0.8279,1.992334 0.8279,4.450237 0,2.457734 -0.37041,4.450062 -0.8279,4.450062 H 47.993582 c -0.457125,0 -0.827657,-1.992328 -0.827657,-4.450062 0,-2.457903 0.370532,-4.450237 0.827657,-4.450237 l 116.458588,1.68e-4"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="75.498604"
+       y="67.291161"
+       width="64.760406"
+       height="6.2646656"
+       stroke="#000000"
+       stroke-width="0.248847"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="121.97231"
+       y="61.738594"
+       transform="scale(0.86254171,1.1593642)">DN-1</text>
+    <rect
+       x="18.587944"
+       y="18.8223"
+       width="18.520494"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="26.58005"
+       y="19.647791"
+       transform="scale(0.86254171,1.1593642)">IP 192.0.2.1<tspan
+   font-size="2.70177px"
+   x="30.083824"
+   y="22.918352"
+   >192.0.2.88</tspan></text>
+    <rect
+       x="175.95082"
+       y="18.8223"
+       width="18.643147"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="209.06046"
+       y="19.647791"
+       transform="scale(0.86254171,1.1593642)">IP 192.0.2.1<tspan
+   font-size="2.70177px"
+   x="212.56424"
+   y="22.918352"
+   >192.0.2.88</tspan></text>
+    <path
+       d="m 38.93289,74.545 c -0.211698,0 -0.383288,-0.922558 -0.383288,-2.060756 0,-1.138192 0.17159,-2.06075 0.383288,-2.06075 0.211699,0 0.383289,0.922558 0.383289,2.06075 0,1.138198 -0.17159,2.060756 -0.383289,2.060756 H 15.904925 c -0.211698,0 -0.383288,-0.922558 -0.383288,-2.060756 0,-1.138192 0.17159,-2.06075 0.383288,-2.06075 H 38.93289"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="28.600546"
+       y="63.729374"
+       transform="scale(0.86254171,1.1593642)">App-1</text>
+    <path
+       d="m 196.54046,74.380136 c -0.21097,0 -0.38268,-0.922558 -0.38268,-2.06075 0,-1.138192 0.17171,-2.06075 0.38268,-2.06075 0.21219,0 0.38389,0.922558 0.38389,2.06075 0,1.138192 -0.1717,2.06075 -0.38389,2.06075 h -22.90532 c -0.21096,0 -0.38267,-0.922558 -0.38267,-2.06075 0,-1.138192 0.17171,-2.06075 0.38267,-2.06075 h 22.90532"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="211.2034"
+       y="63.587162"
+       transform="scale(0.86254171,1.1593642)">App-1</text>
+    <rect
+       x="18.587944"
+       y="9.2604179"
+       width="9.3215733"
+       height="9.5618992"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="24.666197"
+       y="11.684663"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="26.510981"
+   y="13.675445"
+   >0</tspan></text>
+    <rect
+       x="27.909517"
+       y="9.2604179"
+       width="9.1989079"
+       height="9.5618992"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="35.388119"
+       y="11.684663"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="37.232903"
+   y="13.675445"
+   >1</tspan></text>
+    <rect
+       x="81.14061"
+       y="91.855301"
+       width="9.1989079"
+       height="9.5618668"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="97.062386"
+       y="82.926193"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="98.907173"
+   y="84.916969"
+   >0</tspan></text>
+    <rect
+       x="90.339523"
+       y="91.855301"
+       width="9.3215971"
+       height="9.5618668"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="107.81644"
+       y="82.926193"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="109.66123"
+   y="84.916969"
+   >1</tspan></text>
+    <rect
+       x="113.0302"
+       y="91.690437"
+       width="9.1989212"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="134.04214"
+       y="82.783989"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="135.88695"
+   y="84.774765"
+   >0</tspan></text>
+    <rect
+       x="122.22912"
+       y="91.690437"
+       width="9.1989336"
+       height="9.3970232"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="144.76392"
+       y="82.783989"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="146.60869"
+   y="84.774765"
+   >1</tspan></text>
+    <path
+       d="m 73.168207,32.835403 c 0,-2.276221 1.345373,-4.121499 3.004984,-4.121499 1.659605,0 3.004978,1.845278 3.004978,4.121499 0,2.276228 -1.345373,4.121506 -3.004978,4.121506 -1.659611,0 -3.004984,-1.845278 -3.004984,-4.121506 z"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="4.69255px"
+       
+       x="86.610924"
+       y="30.028288"
+       transform="scale(0.86254171,1.1593642)">R</text>
+    <path
+       d="m 133.63579,33.000267 c 0,-2.276227 1.34549,-4.121505 3.00497,-4.121505 1.65949,0 3.00499,1.845278 3.00499,4.121505 0,2.276222 -1.3455,4.1215 -3.00499,4.1215 -1.65948,0 -3.00497,-1.845278 -3.00497,-4.1215 z"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="4.69255px"
+       
+       x="156.84227"
+       y="30.312691"
+       transform="scale(0.86254171,1.1593642)">E</text>
+    <path
+       d="m 73.168207,114.93571 c 0,-2.27622 1.345373,-4.1215 3.004984,-4.1215 1.659605,0 3.004978,1.84528 3.004978,4.1215 0,2.27622 -1.345373,4.1215 -3.004978,4.1215 -1.659611,0 -3.004984,-1.84528 -3.004984,-4.1215 z"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="4.69255px"
+       
+       x="86.610924"
+       y="100.84322"
+       transform="scale(0.86254171,1.1593642)">R</text>
+    <path
+       d="m 133.63579,115.10057 c 0,-2.27623 1.34549,-4.1215 3.00497,-4.1215 1.65949,0 3.00499,1.84527 3.00499,4.1215 0,2.27622 -1.3455,4.1215 -3.00499,4.1215 -1.65948,0 -3.00497,-1.84528 -3.00497,-4.1215 z"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="4.69255px"
+       
+       x="156.84227"
+       y="101.12761"
+       transform="scale(0.86254171,1.1593642)">E</text>
+    <path
+       d="m 35.820589,63.417604 c 0,-0.364503 0.219915,-0.660098 0.4911,-0.660098 h 14.839944 c 0.271184,0 0.4911,0.295595 0.4911,0.660098 v 19.122447 c 0,0.364503 -0.219916,0.660098 -0.4911,0.660098 H 36.311689 c -0.271185,0 -0.4911,-0.295595 -0.4911,-0.660098 z"
+       stroke="#000000"
+       stroke-width="0.663589"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.65438, 1.99078"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 161.53917,63.258018 c 0,-0.36747 0.22201,-0.665377 0.49552,-0.665377 h 14.95377 c 0.27351,0 0.49552,0.297907 0.49552,0.665377 v 19.276755 c 0,0.367476 -0.22201,0.665376 -0.49552,0.665376 h -14.95377 c -0.27351,0 -0.49552,-0.2979 -0.49552,-0.665376 z"
+       stroke="#000000"
+       stroke-width="0.663589"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.65438, 1.99078"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.70177px"
+       
+       x="43.589001"
+       y="76.811646"
+       transform="scale(0.86254171,1.1593642)">aggregation<tspan
+   font-size="2.70177px"
+   x="187.70877"
+   y="76.953835"
+   >disaggregation</tspan></text>
+    <path
+       d="m 110.4545,87.903088 c 0,-0.457693 -0.27604,-0.828726 -0.61655,-0.828726 h -6.73929 c -0.34053,0 -0.61657,0.371033 -0.61657,0.828726 v 7.244984 c 0,0.457699 0.27604,0.828732 0.61657,0.828732 h 6.73929 c 0.34051,0 0.61655,-0.371033 0.61655,-0.828732 z"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 108.9146,87.7338 v 0.939898 h -1.63618 l -0.87145,2.10904 -0.88922,-2.10904 h -1.6184 V 87.7338 l -1.0493,1.192064 1.0493,1.192058 v -0.802344 h 1.156 l 0.99593,2.315351 -0.99593,2.338276 h -1.156 v -0.871122 l -1.0493,1.192071 1.0493,1.19207 v -0.894057 h 1.6184 l 0.88922,-2.154881 0.87145,2.154881 h 1.63618 v 0.848191 l 1.04929,-1.146204 -1.04929,-1.192071 v 0.871122 h -1.13821 l -1.01372,-2.338276 0.99593,-2.315351 h 1.156 v 0.779427 l 1.04929,-1.169141 z"
+       stroke="#000000"
+       stroke-width="0.248847"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 141.73084,66.636141 c 0,-0.457693 -0.27605,-0.828726 -0.61656,-0.828726 h -6.7393 c -0.34051,0 -0.61656,0.371033 -0.61656,0.828726 v 7.244984 c 0,0.457699 0.27605,0.828733 0.61656,0.828733 h 6.7393 c 0.34051,0 0.61656,-0.371034 0.61656,-0.828733 z"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 140.19093,66.301995 v 0.959894 h -1.63618 l -0.87145,2.153914 -0.88923,-2.153914 h -1.61839 v -0.959894 l -1.0493,1.217424 1.0493,1.217425 v -0.819418 h 1.156 l 0.99593,2.36462 -0.99593,2.388029 h -1.156 v -0.889646 l -1.0493,1.217424 1.0493,1.217425 v -0.913075 h 1.61839 l 0.88923,-2.200734 0.87145,2.200734 h 1.63618 v 0.866255 l 1.04929,-1.170605 -1.04929,-1.217424 v 0.889646 h -1.13821 l -1.01372,-2.388029 0.99593,-2.36462 h 1.156 v 0.796008 l 1.04929,-1.194015 z"
+       stroke="#000000"
+       stroke-width="0.248847"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 47.165925,66.471283 c 0,-0.457693 -0.276041,-0.828725 -0.616554,-0.828725 h -6.739296 c -0.34052,0 -0.616561,0.371032 -0.616561,0.828725 v 7.244984 c 0,0.457699 0.276041,0.828733 0.616561,0.828733 h 6.739296 c 0.340513,0 0.616554,-0.371034 0.616554,-0.828733 z"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 45.626028,66.137137 v 0.959894 h -1.636184 l -0.871432,2.153914 -0.889229,-2.153914 h -1.618397 v -0.959894 l -1.04929,1.217424 1.04929,1.217425 v -0.819418 h 1.155998 l 0.995936,2.36462 -0.995936,2.388029 h -1.155998 v -0.889646 l -1.04929,1.217424 1.04929,1.217425 v -0.913075 h 1.618397 l 0.889229,-2.200734 0.871432,2.200734 h 1.636184 V 74.0036 l 1.049287,-1.170605 -1.049287,-1.217424 v 0.889646 h -1.138216 l -1.013708,-2.388029 0.995924,-2.36462 h 1.156 v 0.796008 l 1.049287,-1.194015 z"
+       stroke="#000000"
+       stroke-width="0.248847"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 15.521637,66.486636 c 0,-0.466173 -0.281155,-0.844078 -0.627975,-0.844078 H 8.1772068 c -0.3468227,0 -0.6279765,0.377905 -0.6279765,0.844078 v 7.379124 c 0,0.466173 0.2811538,0.844085 0.6279765,0.844085 h 6.7164552 c 0.34682,0 0.627975,-0.377912 0.627975,-0.844085 z"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 13.981736,66.301995 v 0.939899 h -1.636179 l -0.871445,2.109039 -0.889229,-2.109039 H 8.9664865 v -0.939899 l -1.0492994,1.192064 1.0492994,1.192059 v -0.802345 h 1.1559965 l 0.995938,2.315352 -0.995938,2.338275 H 8.9664865 v -0.871122 l -1.0492994,1.192071 1.0492994,1.192071 v -0.894058 h 1.6183965 l 0.889229,-2.15488 0.871445,2.15488 h 1.636179 v 0.848192 l 1.049292,-1.146205 -1.049292,-1.192071 V 72.5374 h -1.138211 l -1.013722,-2.338275 0.995937,-2.315352 h 1.155996 V 68.6632 l 1.049292,-1.169141 z"
+       stroke="#000000"
+       stroke-width="0.248847"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 172.76186,66.800999 c 0,-0.457693 -0.27604,-0.828726 -0.61655,-0.828726 h -6.73928 c -0.34051,0 -0.61656,0.371033 -0.61656,0.828726 v 7.244965 c 0,0.457687 0.27605,0.828721 0.61656,0.828721 h 6.73928 c 0.34051,0 0.61655,-0.371034 0.61655,-0.828721 z"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 171.32652,66.631717 v 0.939899 h -1.66439 l -0.88647,2.109039 -0.90456,-2.109039 h -1.64631 v -0.939899 l -1.06739,1.192071 1.06739,1.19207 v -0.802357 h 1.17593 l 1.01312,2.315358 -1.01312,2.338294 h -1.17593 v -0.871121 l -1.06739,1.192052 1.06739,1.19207 v -0.894051 h 1.64631 l 0.90456,-2.154887 0.88647,2.154887 h 1.66439 v 0.848204 l 1.06738,-1.146223 -1.06738,-1.192052 v 0.871121 h -1.15783 l -1.03121,-2.338294 1.01311,-2.315358 h 1.17593 v 0.779421 l 1.06738,-1.169134 z"
+       stroke="#000000"
+       stroke-width="0.248847"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 204.5288,66.48663 c 0,-0.466167 -0.28116,-0.844072 -0.62797,-0.844072 h -6.71644 c -0.34682,0 -0.62797,0.377905 -0.62797,0.844072 v 7.379111 c 0,0.46618 0.28115,0.844086 0.62797,0.844086 h 6.71644 c 0.34681,0 0.62797,-0.377906 0.62797,-0.844086 z"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 203.09346,66.301995 v 0.939899 h -1.66439 l -0.88647,2.109039 -0.90456,-2.109039 h -1.64632 v -0.939899 l -1.06737,1.192064 1.06737,1.192059 v -0.802345 h 1.17593 l 1.01312,2.315352 -1.01312,2.338275 h -1.17593 v -0.871122 l -1.06737,1.192071 1.06737,1.192071 v -0.894058 h 1.64632 l 0.90456,-2.15488 0.88647,2.15488 h 1.66439 v 0.848192 l 1.06738,-1.146205 -1.06738,-1.192071 V 72.5374 h -1.15784 l -1.0312,-2.338275 1.01311,-2.315352 h 1.17593 V 68.6632 l 1.06738,-1.169141 z"
+       stroke="#000000"
+       stroke-width="0.248847"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="49.864277"
+       y="9.2604179"
+       width="9.1989079"
+       height="9.5618992"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="60.846794"
+       y="11.684663"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="62.691586"
+   y="13.675445"
+   >0</tspan></text>
+    <rect
+       x="59.185848"
+       y="9.2604179"
+       width="9.1989079"
+       height="9.5618992"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="71.663422"
+       y="11.684663"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="73.508209"
+   y="13.675445"
+   >1</tspan></text>
+    <rect
+       x="81.263252"
+       y="9.2604179"
+       width="9.1989079"
+       height="9.5618992"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="97.228035"
+       y="11.684663"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="99.07283"
+   y="13.675445"
+   >0</tspan></text>
+    <rect
+       x="90.462181"
+       y="9.2604179"
+       width="9.1989336"
+       height="9.5618992"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="107.94997"
+       y="11.684663"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="109.79475"
+   y="13.675445"
+   >1</tspan></text>
+    <rect
+       x="112.66224"
+       y="9.2604179"
+       width="9.3215847"
+       height="9.5618992"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="133.7037"
+       y="11.684663"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="135.54849"
+   y="13.675445"
+   >0</tspan></text>
+    <rect
+       x="121.98381"
+       y="9.2604179"
+       width="9.1989212"
+       height="9.5618992"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="144.49089"
+       y="11.684663"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="146.33569"
+   y="13.675445"
+   >1</tspan></text>
+    <rect
+       x="144.30653"
+       y="9.2604179"
+       width="9.1989212"
+       height="9.5618992"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="170.34546"
+       y="11.684663"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="172.19025"
+   y="13.675445"
+   >0</tspan></text>
+    <rect
+       x="153.6281"
+       y="9.2604179"
+       width="9.1989212"
+       height="9.5618992"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="181.15396"
+       y="11.684663"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="182.99878"
+   y="13.675445"
+   >1</tspan></text>
+    <rect
+       x="176.07347"
+       y="9.2604179"
+       width="9.1989212"
+       height="9.5618992"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="207.15359"
+       y="11.684663"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="208.9984"
+   y="13.675445"
+   >0</tspan></text>
+    <rect
+       x="185.2724"
+       y="9.2604179"
+       width="9.3215733"
+       height="9.5618992"
+       stroke="#000000"
+       stroke-width="0.331796"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.70639px"
+       
+       x="217.89526"
+       y="11.684663"
+       transform="scale(0.86254171,1.1593642)">DATA <tspan
+   font-size="1.70639px"
+   x="219.74005"
+   y="13.675445"
+   >1</tspan></text>
+  </g>
+</svg>
+</artwork>
+</artset>
+        </figure>
+        <figure anchor="case-a1-pipe">
+                <name>Case A-1 Example JSON Operational/Configuration</name>
+          <artset>
+            <artwork align="left" type="ascii-art" name="" alt=""><![CDATA[
+        
+Please consult the PDF or HTML versions for the Case A-1 Diagram.
+]]></artwork>
+        <artwork type="svg">
+<svg
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="210mm"
+   height="100mm"
+   viewBox="0 0 210 110"
+   version="1.1"
+   >
+  <g
+     >
+    <path
+       d="m 70.117127,15.966295 c 0,1.251181 -3.545926,2.265539 -7.920122,2.265539 -4.374193,0 -7.920122,-1.014358 -7.920122,-2.265539 0,-1.251181 3.545929,-2.265538 7.920122,-2.265538 4.374196,0 7.920122,1.014357 7.920122,2.265538 v 18.325689 c 0,1.251181 -3.545926,2.265535 -7.920122,2.265535 -4.374193,0 -7.920122,-1.014354 -7.920122,-2.265535 V 15.966295"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 85.781367,15.966295 c 0,1.251181 -3.545927,2.265539 -7.920114,2.265539 -4.374196,0 -7.920127,-1.014358 -7.920127,-2.265539 0,-1.251181 3.545931,-2.265538 7.920127,-2.265538 4.374187,0 7.920114,1.014357 7.920114,2.265538 v 18.325689 c 0,1.251181 -3.545927,2.265535 -7.920114,2.265535 -4.374196,0 -7.920127,-1.014354 -7.920127,-2.265535 V 15.966295"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 85.69337,40.987905 c 0,2.502463 -7.091939,4.531078 -15.840247,4.531078 -8.748302,0 -15.840245,-2.028615 -15.840245,-4.531078 0,-2.502464 7.091943,-4.531079 15.840245,-4.531079 8.748308,0 15.840247,2.028615 15.840247,4.531079 v 50.244609 c 0,2.502158 -7.091939,4.531073 -15.840247,4.531073 -8.748302,0 -15.840245,-2.028915 -15.840245,-4.531073 V 40.987905"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 133.1261,15.676809 c 0,1.258129 -3.56581,2.278125 -7.96413,2.278125 -4.39831,0 -7.96412,-1.019996 -7.96412,-2.278125 0,-1.258128 3.56581,-2.278124 7.96412,-2.278124 4.39832,0 7.96413,1.019996 7.96413,2.278124 v 18.401202 c 0,1.258232 -3.56581,2.278131 -7.96413,2.278131 -4.39831,0 -7.96412,-1.019899 -7.96412,-2.278131 V 15.676809"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 149.05434,15.664224 c 0,1.25118 -3.54557,2.265538 -7.92012,2.265538 -4.37454,0 -7.92012,-1.014358 -7.92012,-2.265538 0,-1.251182 3.54558,-2.265539 7.92012,-2.265539 4.37455,0 7.92012,1.014357 7.92012,2.265539 v 18.426375 c 0,1.251181 -3.54557,2.265543 -7.92012,2.265543 -4.37454,0 -7.92012,-1.014362 -7.92012,-2.265543 V 15.664224"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 148.70234,40.685834 c 0,2.502362 -7.09203,4.531079 -15.84025,4.531079 -8.74821,0 -15.84024,-2.028717 -15.84024,-4.531079 0,-2.502464 7.09203,-4.531078 15.84024,-4.531078 8.74822,0 15.84025,2.028614 15.84025,4.531078 v 50.345302 c 0,2.502158 -7.09203,4.531074 -15.84025,4.531074 -8.74821,0 -15.84024,-2.028916 -15.84024,-4.531074 V 40.685834"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 7.6801753,36.607869 H 197.36973"
+       stroke="#000000"
+       stroke-width="0.109821"
+       stroke-miterlimit="8"
+       stroke-dasharray="0.439283, 0.329462"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 7.6801753,64.398471 H 197.36973"
+       stroke="#000000"
+       stroke-width="0.109821"
+       stroke-miterlimit="8"
+       stroke-dasharray="0.439283, 0.329462"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 7.5041615,95.914628 H 197.19373"
+       stroke="#000000"
+       stroke-width="0.109821"
+       stroke-miterlimit="8"
+       stroke-dasharray="0.439283, 0.329462"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="56.828926"
+       y="19.742193"
+       width="11.528177"
+       height="9.2635345"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.10637px"
+       
+       x="62.83218"
+       y="23.916018"
+       
+       transform="scale(0.93486789,1.0696699)">app-<tspan
+   font-size="3.10637px"
+   x="69.366539"
+   y="23.916018"
+   
+   >0</tspan></text>
+    <rect
+       x="64.397034"
+       y="45.3176"
+       width="11.528177"
+       height="9.1628437"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.95356px"
+       
+       x="70.943565"
+       y="48.108047"
+       
+       transform="scale(0.93486789,1.0696699)">ssl-<tspan
+   font-size="3.95356px"
+   x="76.928833"
+   y="48.108047"
+   
+   >1</tspan></text>
+    <rect
+       x="64.397034"
+       y="76.028236"
+       width="11.528177"
+       height="9.1628532"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.95356px"
+       
+       x="71.163277"
+       y="76.818428"
+       
+       transform="scale(0.93486789,1.0696699)">fsl-<tspan
+   font-size="3.95356px"
+   x="76.709236"
+   y="76.818428"
+   
+   >1</tspan><tspan
+   font-size="2.44744px"
+   x="61.926182"
+   y="30.317019"
+   
+   >outgoing</tspan><tspan
+   font-size="2.44744px"
+   x="62.749847"
+   y="33.235126"
+   
+   >-</tspan><tspan
+   font-size="2.44744px"
+   x="63.738243"
+   y="33.235126"
+   
+   >service</tspan><tspan
+   font-size="2.44744px"
+   x="69.996414"
+   y="54.132515"
+   
+   >outgoing</tspan><tspan
+   font-size="2.44744px"
+   x="63.544426"
+   y="57.050625"
+   
+   >forwarding sub-layer</tspan><tspan
+   font-size="2.44744px"
+   x="69.927788"
+   y="66.746262"
+   
+   >incoming</tspan><tspan
+   font-size="2.44744px"
+   x="65.782036"
+   y="69.66436"
+   
+   >service sub-layer</tspan><tspan
+   font-size="2.44744px"
+   x="69.996429"
+   y="82.937042"
+   
+   >outgoing</tspan><tspan
+   font-size="2.44744px"
+   x="70.298439"
+   y="85.855148"
+   
+   >interface</tspan></text>
+    <rect
+       x="71.613152"
+       y="19.742193"
+       width="11.528177"
+       height="9.1628437"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.10637px"
+       
+       x="78.646332"
+       y="23.916018"
+       
+       transform="scale(0.93486789,1.0696699)">app-<tspan
+   font-size="3.10637px"
+   x="85.180687"
+   y="23.916018"
+   
+   >1</tspan><tspan
+   font-size="2.44744px"
+   x="77.740288"
+   y="30.317019"
+   
+   >outgoing</tspan><tspan
+   font-size="2.44744px"
+   x="78.56395"
+   y="33.23513"
+   
+   >-</tspan><tspan
+   font-size="2.44744px"
+   x="79.552345"
+   y="33.23513"
+   
+   >service</tspan><tspan
+   font-size="2.44744px"
+   x="64.253578"
+   y="93.103333"
+   
+   >Case A</tspan><tspan
+   font-size="2.44744px"
+   x="71.831245"
+   y="93.103333"
+   
+   >-</tspan><tspan
+   font-size="2.44744px"
+   x="72.819626"
+   y="93.103333"
+   
+   >1 (Ingress 1)</tspan></text>
+    <rect
+       x="54.012878"
+       y="16.620783"
+       width="31.680489"
+       height="79.142799"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <path
+       d="m 62.641766,37.092997 0.897524,3.131074 -0.09759,0.03655 -0.897438,-3.130971 z m 1.370094,2.70646 -0.201349,1.559095 -0.969336,-1.119784 z"
+       
+        />
+    <path
+       d="m 77.359744,37.097443 -0.669885,3.152995 0.09977,0.02776 0.669885,-3.152994 z m -1.170081,2.772081 0.307559,1.536272 0.889602,-1.203286 z"
+       
+        />
+    <path
+       d="m 70.109796,62.586042 -1.2e-5,4.259469 h 0.102668 l 1.3e-5,-4.259469 z m -0.564687,4.024516 0.616005,1.409682 0.616015,-1.409666 z"
+       
+        />
+    <path
+       d="m 70.109796,92.088386 -1.2e-5,4.259462 h 0.102668 l 1.3e-5,-4.259462 z m -0.564687,4.024511 0.616005,1.40968 0.616015,-1.409662 z"
+       
+        />
+    <text
+       font-size="2.44744px"
+       
+       x="69.92778"
+       y="38.035889"
+       
+       transform="scale(0.93486789,1.0696699)">incoming<tspan
+   font-size="2.44744px"
+   x="70.134247"
+   y="40.953987"
+   
+   >app-flow</tspan></text>
+    <path
+       d="m 62.541679,13.751102 -1.3e-5,4.259474 h 0.102668 l 1.3e-5,-4.259474 z m -0.564688,4.024521 0.616005,1.409679 0.616015,-1.409668 z"
+       
+        />
+    <path
+       d="m 77.325907,13.751102 -1e-5,4.259474 h 0.102661 l 2e-5,-4.259474 z m -0.564686,4.024521 0.616007,1.409679 0.616015,-1.409668 z"
+       
+        />
+    <rect
+       x="120.01389"
+       y="19.742193"
+       width="11.528177"
+       height="9.2635345"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.95356px"
+       
+       x="131.13994"
+       y="24.292547"
+       
+       transform="scale(0.93486789,1.0696699)">app</text>
+    <rect
+       x="127.75803"
+       y="45.3176"
+       width="11.528177"
+       height="9.1628437"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.95356px"
+       
+       x="140.07307"
+       y="48.108047"
+       
+       transform="scale(0.93486789,1.0696699)">svc</text>
+    <rect
+       x="127.75803"
+       y="76.028236"
+       width="11.528177"
+       height="9.1628532"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.95356px"
+       
+       x="139.4951"
+       y="76.818428"
+       
+       transform="scale(0.93486789,1.0696699)">fwd</text>
+    <rect
+       x="134.79814"
+       y="19.742193"
+       width="11.528177"
+       height="9.1628437"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.95356px"
+       
+       x="146.95418"
+       y="24.198412"
+       
+       transform="scale(0.93486789,1.0696699)">app<tspan
+   font-size="2.44744px"
+   x="145.25192"
+   y="30.317019"
+   
+   >incoming</tspan><tspan
+   font-size="2.44744px"
+   x="146.14368"
+   y="33.23513"
+   
+   >-</tspan><tspan
+   font-size="2.44744px"
+   x="147.13206"
+   y="33.23513"
+   
+   >service</tspan><tspan
+   font-size="2.44744px"
+   x="132.23195"
+   y="93.103333"
+   
+   >Case A</tspan><tspan
+   font-size="2.44744px"
+   x="139.80963"
+   y="93.103333"
+   
+   >-</tspan><tspan
+   font-size="2.44744px"
+   x="140.798"
+   y="93.103333"
+   
+   >1 (Egress 1)</tspan></text>
+    <rect
+       x="117.19786"
+       y="16.620783"
+       width="31.680489"
+       height="79.142799"
+       stroke="#000000"
+       stroke-width="0.219642"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.44744px"
+       
+       x="129.43707"
+       y="30.128754"
+       
+       transform="scale(0.93486789,1.0696699)">incoming<tspan
+   font-size="2.44744px"
+   x="130.32991"
+   y="33.046867"
+   
+   >-service</tspan><tspan
+   font-size="2.44744px"
+   x="137.7811"
+   y="65.7108"
+   
+   >outgoing</tspan><tspan
+   font-size="2.44744px"
+   x="133.56725"
+   y="68.628922"
+   
+   >service sub-layer</tspan><tspan
+   font-size="2.44744px"
+   x="137.71303"
+   y="53.285324"
+   
+   >incoming</tspan><tspan
+   font-size="2.44744px"
+   x="131.48065"
+   y="56.20343"
+   
+   >service-identification</tspan><tspan
+   font-size="2.44744px"
+   x="137.78165"
+   y="37.659351"
+   
+   >outgoing</tspan><tspan
+   font-size="2.44744px"
+   x="137.91891"
+   y="40.577454"
+   
+   >app-flow</tspan><tspan
+   font-size="2.44744px"
+   x="137.71245"
+   y="82.372231"
+   
+   >incoming</tspan><tspan
+   font-size="2.44744px"
+   x="129.24306"
+   y="85.290337"
+   
+   >forwarding-identification</tspan></text>
+    <path
+       d="m 126.14671,38.209251 0.89761,3.130972 -0.0977,0.03663 -0.89762,-3.131074 z m -0.57025,0.46116 0.20152,-1.559094 0.96891,1.119784 z"
+       
+        />
+    <path
+       d="m 140.30237,38.238921 -0.66989,3.152994 0.0998,0.02776 0.66988,-3.152995 z m 0.59996,0.40866 -0.30756,-1.536264 -0.88959,1.203286 z"
+       
+        />
+    <path
+       d="m 133.29477,63.760764 -2e-5,4.259476 h 0.10267 l 1e-5,-4.259476 z m 0.66734,0.234944 -0.61602,-1.409666 -0.616,1.409666 z"
+       
+        />
+    <text
+       font-size="2.44744px"
+       
+       x="102.15749"
+       y="40.106789"
+       
+       transform="scale(0.93486789,1.0696699)">App to Svc</text>
+    <path
+       d="m 133.29477,93.263106 -2e-5,4.259471 h 0.10267 l 1e-5,-4.259471 z m 0.66734,0.234943 -0.61602,-1.409663 -0.616,1.409663 z"
+       
+        />
+    <path
+       d="m 125.72665,14.925829 -2e-5,4.259473 h 0.10268 l 10e-6,-4.259473 z m 0.66733,0.234941 -0.616,-1.409668 -0.61601,1.409668 z"
+       
+        />
+    <path
+       d="m 140.51088,14.925829 -2e-5,4.259473 h 0.10267 l 1e-5,-4.259473 z m 0.66734,0.234941 -0.61602,-1.409668 -0.616,1.409668 z"
+       
+        />
+    <path
+       d="m 49.656812,18.212299 c 0,-0.851137 0.603074,-1.54117 1.346949,-1.54117 H 151.97511 c 0.74449,0 1.34729,0.690033 1.34729,1.54117 v 44.644999 c 0,0.851139 -0.6028,1.541173 -1.34729,1.541173 H 51.003761 c -0.743875,0 -1.346949,-0.690034 -1.346949,-1.541173 z"
+       stroke="#000000"
+       stroke-width="0.439283"
+       stroke-miterlimit="8"
+       stroke-dasharray="1.75714, 1.31786"
+       fill="none"
+       fill-rule="evenodd"
+        />
+  </g>
+</svg>
+</artwork>
+</artset>
+        </figure>
+        <figure anchor="example-detnet-json-configuration-a-1">
+          <name>Example A-1 DetNet JSON configuration</name>
+          <artwork name="" type="" align="left" alt=""><![CDATA[
+{
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "eth0",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth1",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth2",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth3",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth4",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      }
+    ]
+  },
+  "ietf-detnet:detnet": {
+    "app-flows": {
+      "app-flow": [
+        {
+          "name": "app-0",
+          "app-flow-bidir-congruent": false,
+          "outgoing-service": "ssl-1",
+          "traffic-profile": "pf-1",
+          "ingress": {
+            "app-flow-status": "ready",
+            "interface": "eth0",
+            "ip-app-flow": {
+              "src-ip-prefix": "192.0.2.1/32",
+              "dest-ip-prefix": "192.0.2.88/32",
+              "dscp": 6
+            }
+          }
+        },
+        {
+          "name": "app-1",
+          "app-flow-bidir-congruent": false,
+          "outgoing-service": "ssl-1",
+          "traffic-profile": "pf-1",
+          "ingress": {
+            "app-flow-status": "ready",
+            "interface": "eth0",
+            "ip-app-flow": {
+              "src-ip-prefix": "192.0.2.1/32",
+              "dest-ip-prefix": "192.0.2.88/32",
+              "dscp": 7
+            }
+          }
+        }
+      ]
+    },
+    "traffic-profile": [
+      {
+        "profile-name": "pf-1",
+        "traffic-requirements": {
+          "min-bandwidth": "100000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 200000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "flow-spec": {
+          "interval": 5,
+          "max-pkts-per-interval": 10,
+          "max-payload-size": 1500,
+          "min-payload-size": 100,
+          "min-pkts-per-interval": 1
+        },
+        "member-apps": [
+          "app-0",
+          "app-1"
+        ]
+      },
+      {
+        "profile-name": "pf-2",
+        "traffic-requirements": {
+          "min-bandwidth": "200000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 200000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "flow-spec": {
+          "interval": 5,
+          "max-pkts-per-interval": 10,
+          "max-payload-size": 1500,
+          "min-payload-size": 100,
+          "min-pkts-per-interval": 1
+        },
+        "member-services": [
+          "ssl-1"
+        ]
+      },
+      {
+        "profile-name": "pf-3",
+        "flow-spec": {
+          "interval": 5,
+          "max-pkts-per-interval": 10,
+          "max-payload-size": 1500
+        },
+        "member-fwd-sublayers": [
+          "fsl-1"
+        ]
+      }
+    ],
+    "service-sub-layer": {
+      "service-sub-layer-list": [
+        {
+          "name": "ssl-1",
+          "service-rank": 10,
+          "traffic-profile": "pf-2",
+          "service-operation-type": "service-initiation",
+          "service-protection": {
+            "service-protection-type": "none",
+            "sequence-number-length": "long-sn"
+          },
+          "incoming-type": {
+            "app-flow": {
+              "app-flow-list": [
+                "app-0",
+                "app-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 100
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-1"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "forwarding-sub-layer": {
+      "forwarding-sub-layer-list": [
+        {
+          "name": "fsl-1",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth2",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10000
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+]]></artwork>
+        </figure>
+      </section>
+      <section numbered="true" toc="default">
+        <name>Example B-1 XML Config: Aggregation using a Forwarding Sub-layer</name>
+        <t>
+                This illustrates aggrgation in the service sub-layers of DetNet.
+                Flows 1 and 2 are aggregated into a forwarding sub-layer. A diagram 
+                illustrating this case is shown and then the 
+                corresponding XML operational data follows.
+        </t>
+        <figure anchor="case-b1">
+                <name>Case B-1 Example XML Config: Aggregation using a Forwarding Sub-layer</name>
+          <artset>
+            <artwork align="left" type="ascii-art" name="" alt=""><![CDATA[
+        
+Please consult the PDF or HTML versions for the Case B-1 Diagram.
+
+]]></artwork>
+        <artwork type="svg">
+<svg
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="210mm"
+   height="120mm"
+   viewBox="0 15 210 110"
+   version="1.1"
+   >
+  <g
+     >
+    <path
+       d="m 79.692681,65.419668 c 0,-0.405703 -0.258207,-0.734588 -0.576725,-0.734588 h -6.168305 c -0.318517,0 -0.576725,0.328885 -0.576725,0.734588 v 6.421941 c 0,0.405702 0.258208,0.734587 0.576725,0.734587 h 6.168305 c 0.318518,0 0.576725,-0.328885 0.576725,-0.734587 z"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 78.503741,65.258978 v 0.817977 h -1.502646 l -0.800326,1.835462 -0.816656,-1.835462 h -1.486312 v -0.817977 l -0.963667,1.037433 0.963667,1.037428 v -0.698267 h 1.061654 l 0.914652,2.015011 -0.914652,2.034961 h -1.061654 v -0.758123 l -0.963667,1.037439 0.963667,1.037439 v -0.778083 h 1.486312 l 0.816656,-1.875355 0.800326,1.875355 h 1.502646 v 0.738166 l 0.963655,-0.997522 -0.963655,-1.037439 v 0.758123 h -1.045319 l -0.930987,-2.034961 0.914653,-2.015011 h 1.061653 v 0.678322 l 0.963655,-1.017483 z"
+       stroke="#000000"
+       stroke-width="0.222473"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 195.37627,32.407082 c 0,-0.398322 -0.25351,-0.721226 -0.56624,-0.721226 h -6.18928 c -0.31273,0 -0.56623,0.322904 -0.56623,0.721226 v 6.305186 c 0,0.398327 0.2535,0.721232 0.56623,0.721232 h 6.18928 c 0.31273,0 0.56624,-0.322905 0.56624,-0.721232 z"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 194.05808,32.11628 v 0.83538 h -1.52856 l -0.81413,1.874515 -0.83073,-1.874515 h -1.51196 v -0.83538 l -0.98026,1.059504 0.98026,1.059504 v -0.713126 h 1.07997 l 0.93043,2.057888 -0.93043,2.078262 h -1.07997 v -0.774244 l -0.98026,1.059504 0.98026,1.059503 v -0.794633 h 1.51196 l 0.83073,-1.915261 0.81413,1.915261 h 1.52856 v 0.753887 l 0.98027,-1.018757 -0.98027,-1.059504 v 0.774244 h -1.06335 l -0.94704,-2.078262 0.93042,-2.057888 h 1.07997 v 0.692753 l 0.98027,-1.039131 z"
+       stroke="#000000"
+       stroke-width="0.222473"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 136.83045,68.415423 c -0.42015,0 -0.76033,-1.734322 -0.76033,-3.873821 0,-2.139495 0.34018,-3.873823 0.76033,-3.873823 0.42016,0 0.76035,1.734328 0.76035,3.873823 0,2.139499 -0.34019,3.873821 -0.76035,3.873821 h -5.3505 c -0.42015,0 -0.76033,-1.734322 -0.76033,-3.873821 0,-2.139495 0.34018,-3.873823 0.76033,-3.873823 h 5.3505"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="147.79619"
+       y="56.806286"
+       
+       transform="scale(0.88605917,1.1285928)">DN-2</text>
+    <path
+       d="m 166.6525,65.406306 c 0,-0.398322 -0.25351,-0.721226 -0.56624,-0.721226 h -6.18928 c -0.31272,0 -0.56624,0.322904 -0.56624,0.721226 v 6.305186 c 0,0.398327 0.25352,0.721232 0.56624,0.721232 h 6.18928 c 0.31273,0 0.56624,-0.322905 0.56624,-0.721232 z"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 165.46356,65.258978 v 0.817977 h -1.50265 l -0.80033,1.835462 -0.81666,-1.835462 h -1.4863 v -0.817977 l -0.96367,1.037433 0.96367,1.037428 v -0.698267 h 1.06165 l 0.91465,2.015011 -0.91465,2.034961 h -1.06165 v -0.758123 l -0.96367,1.037439 0.96367,1.037439 v -0.778083 h 1.4863 l 0.81666,-1.875355 0.80033,1.875355 h 1.50265 v 0.738166 l 0.96365,-0.997522 -0.96365,-1.037439 v 0.758123 h -1.04533 l -0.93098,-2.034961 0.91465,-2.015011 h 1.06166 v 0.678322 l 0.96365,-1.017483 z"
+       stroke="#000000"
+       stroke-width="0.222473"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="15.306479"
+       y="66.595085"
+       
+       transform="scale(0.88605917,1.1285928)">Source 1<tspan
+   font-size="2.92393px"
+   x="16.380289"
+   y="69.519012"
+   
+   >192.0.2.1</tspan></text>
+    <path
+       d="m 21.907209,65.406311 c 0,-0.398327 -0.253513,-0.721231 -0.566236,-0.721231 h -6.301901 c -0.312727,0 -0.566239,0.322904 -0.566239,0.721231 v 6.305208 c 0,0.398317 0.253512,0.721221 0.566239,0.721221 h 6.301901 c 0.312723,0 0.566236,-0.322904 0.566236,-0.721221 z"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 20.701656,65.115504 v 0.83538 h -1.528557 l -0.814111,1.874515 -0.830736,-1.874515 h -1.511939 v -0.83538 l -0.980271,1.059504 0.980271,1.059504 v -0.713126 h 1.079955 l 0.930426,2.057888 -0.930426,2.078261 h -1.079955 v -0.774243 l -0.980271,1.059504 0.980271,1.059503 v -0.794633 h 1.511939 l 0.830736,-1.915261 0.814111,1.915261 h 1.528557 v 0.753887 l 0.980266,-1.018757 -0.980266,-1.059504 v 0.774243 h -1.063344 l -0.947042,-2.078261 0.930426,-2.057888 h 1.07996 v 0.692753 l 0.980266,-1.039131 z"
+       stroke="#000000"
+       stroke-width="0.222473"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="47.859951"
+       y="70.663162"
+       
+       transform="scale(0.88605917,1.1285928)">Ingress 1<tspan
+   font-size="2.92393px"
+   x="49.064266"
+   y="73.58709"
+   
+   >192.0.2.2</tspan></text>
+    <path
+       d="m 50.856263,65.406311 c 0,-0.398322 -0.253516,-0.721231 -0.566239,-0.721231 h -6.189256 c -0.312727,0 -0.566239,0.322909 -0.566239,0.721231 v 6.305192 c 0,0.398333 0.253512,0.721237 0.566239,0.721237 h 6.189256 c 0.312723,0 0.566239,-0.322904 0.566239,-0.721237 z"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 49.650711,65.115504 v 0.83538 h -1.528553 l -0.814123,1.874515 -0.830736,-1.874515 h -1.511953 v -0.83538 l -0.980267,1.059504 0.980267,1.059504 v -0.713126 h 1.07996 l 0.930434,2.057888 -0.930434,2.078261 h -1.07996 v -0.774243 l -0.980267,1.059504 0.980267,1.059503 v -0.794633 h 1.511953 l 0.830736,-1.915261 0.814123,1.915261 h 1.528553 v 0.753887 l 0.98027,-1.018757 -0.98027,-1.059504 v 0.774243 h -1.06334 l -0.947042,-2.078261 0.930425,-2.057888 h 1.079957 v 0.692753 l 0.98027,-1.039131 z"
+       stroke="#000000"
+       stroke-width="0.222473"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="146.92918"
+       y="70.663162"
+       
+       transform="scale(0.88605917,1.1285928)">Relay 2<tspan
+   font-size="2.92393px"
+   x="147.11458"
+   y="73.58709"
+   
+   >192.0.2.6</tspan><tspan
+   font-size="2.92393px"
+   x="179.01915"
+   y="70.663162"
+   
+   >Egress 1</tspan><tspan
+   font-size="2.92393px"
+   x="179.7964"
+   y="73.58709"
+   
+   >192.0.2.77</tspan><tspan
+   font-size="2.92393px"
+   x="113.356"
+   y="83.248756"
+   
+   >Transit 2</tspan><tspan
+   font-size="2.92393px"
+   x="114.42986"
+   y="86.172691"
+   
+   >192.0.2.5</tspan></text>
+    <path
+       d="m 108.75438,84.058039 c 0,-0.398323 -0.25351,-0.721226 -0.56623,-0.721226 h -6.18928 c -0.31274,0 -0.56625,0.322903 -0.56625,0.721226 v 6.305184 c 0,0.398331 0.25351,0.721233 0.56625,0.721233 h 6.18928 c 0.31272,0 0.56623,-0.322902 0.56623,-0.721233 z"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 107.56544,83.91071 v 0.817978 h -1.50264 l -0.80032,1.83546 -0.81666,-1.83546 h -1.48631 V 83.91071 l -0.96366,1.037433 0.96366,1.037428 v -0.698267 h 1.06166 l 0.91465,2.015011 -0.91465,2.03496 h -1.06166 V 88.57915 l -0.96366,1.037445 0.96366,1.037436 v -0.778085 h 1.48631 l 0.81666,-1.875354 0.80032,1.875354 h 1.50264 v 0.738171 l 0.96366,-0.997522 -0.96366,-1.037445 v 0.758125 h -1.04532 l -0.93098,-2.03496 0.91465,-2.015011 h 1.06165 v 0.678322 l 0.96366,-1.017483 z"
+       stroke="#000000"
+       stroke-width="0.222473"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="113.35614"
+       y="49.941429"
+       
+       transform="scale(0.88605917,1.1285928)">Transit 1<tspan
+   font-size="2.92393px"
+   x="114.42995"
+   y="52.865356"
+   
+   >192.0.2.4</tspan></text>
+    <path
+       d="m 108.75438,46.611095 c 0,-0.398322 -0.25351,-0.721226 -0.56623,-0.721226 h -6.18928 c -0.31274,0 -0.56625,0.322904 -0.56625,0.721226 v 6.305185 c 0,0.398329 0.25351,0.721233 0.56625,0.721233 h 6.18928 c 0.31272,0 0.56623,-0.322904 0.56623,-0.721233 z"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 107.56544,46.463766 v 0.817979 h -1.50264 l -0.80032,1.83546 -0.81666,-1.83546 h -1.48631 v -0.817979 l -0.96366,1.037439 0.96366,1.037439 v -0.698278 h 1.06166 l 0.91465,2.015017 -0.91465,2.034976 h -1.06166 v -0.758121 l -0.96366,1.037422 0.96366,1.037439 v -0.778078 h 1.48631 l 0.81666,-1.87536 0.80032,1.87536 h 1.50264 v 0.738178 l 0.96366,-0.997539 -0.96366,-1.037422 v 0.758121 h -1.04532 l -0.93098,-2.034976 0.91465,-2.015017 h 1.06165 v 0.678317 l 0.96366,-1.017478 z"
+       stroke="#000000"
+       stroke-width="0.222473"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="208.60622"
+       y="66.595085"
+       
+       transform="scale(0.88605917,1.1285928)">Destination 1<tspan
+   font-size="2.92393px"
+   x="212.48022"
+   y="69.519012"
+   
+   >192.0.2.88</tspan></text>
+    <path
+       d="m 195.60155,65.406306 c 0,-0.398322 -0.25351,-0.721226 -0.56624,-0.721226 h -6.18928 c -0.31272,0 -0.56624,0.322904 -0.56624,0.721226 v 6.305186 c 0,0.398327 0.25352,0.721232 0.56624,0.721232 h 6.18928 c 0.31273,0 0.56624,-0.322905 0.56624,-0.721232 z"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 194.28335,65.115504 v 0.83538 h -1.52855 l -0.81411,1.874515 -0.83074,-1.874515 h -1.51194 v -0.83538 l -0.98027,1.059504 0.98027,1.059504 v -0.713126 h 1.07995 l 0.93043,2.057888 -0.93043,2.078261 h -1.07995 v -0.774243 l -0.98027,1.059504 0.98027,1.059503 v -0.794633 h 1.51194 l 0.83074,-1.915261 0.81411,1.915261 h 1.52855 v 0.753887 l 0.98027,-1.018757 -0.98027,-1.059504 v 0.774243 h -1.06333 l -0.94705,-2.078261 0.93043,-2.057888 h 1.07995 v 0.692753 l 0.98027,-1.039131 z"
+       stroke="#000000"
+       stroke-width="0.222473"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 21.907209,68.558901 H 43.517623"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 50.856263,68.558901 H 72.466682"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 79.805322,68.508395 101.41574,49.76369"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 108.75438,49.76369 130.3648,68.508395"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 137.70344,68.558901 h 21.61041"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 166.6525,68.558901 h 21.61041"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 108.75438,87.268743 130.3648,68.558901"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 79.805322,68.558901 101.41574,87.268884"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="15.189409"
+       y="37.355831"
+       
+       transform="scale(0.88605917,1.1285928)">Source 2<tspan
+   font-size="2.92393px"
+   x="16.263189"
+   y="40.279758"
+   
+   >192.0.2.12</tspan></text>
+    <path
+       d="m 21.794568,32.407082 c 0,-0.398322 -0.253512,-0.721226 -0.566235,-0.721226 h -6.189261 c -0.312727,0 -0.566239,0.322904 -0.566239,0.721226 v 6.305169 c 0,0.398318 0.253512,0.721221 0.566239,0.721221 h 6.189261 c 0.312723,0 0.566235,-0.322903 0.566235,-0.721221 z"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 20.589011,32.11628 v 0.83538 h -1.528553 l -0.814123,1.874515 -0.830736,-1.874515 h -1.511953 v -0.83538 l -0.980267,1.059504 0.980267,1.059504 v -0.713126 h 1.07996 l 0.930435,2.057888 -0.930435,2.078262 h -1.07996 v -0.774244 l -0.980267,1.059504 0.980267,1.059503 v -0.794633 h 1.511953 l 0.830736,-1.915261 0.814123,1.915261 h 1.528553 v 0.753887 l 0.980271,-1.018757 -0.980271,-1.059504 v 0.774244 h -1.06334 l -0.947042,-2.078262 0.930426,-2.057888 h 1.079956 v 0.692753 l 0.980271,-1.039131 z"
+       stroke="#000000"
+       stroke-width="0.222473"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 21.794568,35.559677 43.508725,68.566651"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="24.38534"
+       y="15.903621"
+       width="17.121622"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="31.761442"
+       y="18.922384"
+       
+       transform="scale(0.88605917,1.1285928)">DATA 2</text>
+    <rect
+       x="24.38534"
+       y="24.225159"
+       width="17.121622"
+       height="8.3215294"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="32.095158"
+       y="25.024492"
+       
+       transform="scale(0.88605917,1.1285928)">IP <tspan
+   font-size="2.03404px"
+   x="35.877186"
+   y="25.024492"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="2.03404px"
+   x="35.840099"
+   y="27.69416"
+   
+   >192.0.2.89</tspan><tspan
+   font-size="2.92393px"
+   x="208.60622"
+   y="37.355831"
+   
+   >Destination 2</tspan><tspan
+   font-size="2.92393px"
+   x="212.48105"
+   y="40.279758"
+   
+   >192.0.2.89</tspan></text>
+    <path
+       d="M 166.6525,68.486878 188.26291,35.416205"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="168.90533"
+       y="15.903621"
+       width="17.234264"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="194.91589"
+       y="18.922384"
+       
+       transform="scale(0.88605917,1.1285928)">DATA 2</text>
+    <rect
+       x="168.90533"
+       y="24.225159"
+       width="17.234264"
+       height="8.3215294"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="195.25024"
+       y="25.024492"
+       
+       transform="scale(0.88605917,1.1285928)">IP <tspan
+   font-size="2.03404px"
+   x="199.03227"
+   y="25.024492"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="2.03404px"
+   x="198.99519"
+   y="27.69416"
+   
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 40.652681,66.835338 c -0.124583,-0.191828 0.262682,-0.861712 0.864867,-1.4963 0.602184,-0.634735 1.191303,-0.99371 1.315885,-0.802025 0.124583,0.191828 -0.262567,0.861713 -0.864866,1.496441 -0.602185,0.634589 -1.191303,0.993565 -1.315886,0.801884 L 22.654701,39.128474 c -0.124584,-0.191827 0.262682,-0.861711 0.864866,-1.496446 0.602189,-0.634588 1.191308,-0.993704 1.31589,-0.801878 l 17.997976,27.707005"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       transform="matrix(0.56484303,0.86954548,-0.68268089,0.71945284,0,0)"
+       
+       x="55.302616"
+       y="-1.8589511"
+       >App<tspan
+   font-size="2.92393px"
+   x="60.10194"
+   y="-1.8762535"
+   
+   >-</tspan><tspan
+   font-size="2.92393px"
+   x="60.953308"
+   y="-1.908131"
+   
+   >2</tspan></text>
+    <path
+       d="m 188.03424,39.253299 c -0.12503,0.190964 -0.71302,-0.17217 -1.31228,-0.810782 -0.59925,-0.638748 -0.98336,-1.31136 -0.85833,-1.502178 0.12503,-0.190965 0.71303,0.172023 1.31228,0.810776 0.59925,0.638747 0.9845,1.311213 0.85833,1.502184 l -18.11286,27.584192 c -0.12617,0.190964 -0.71303,-0.172029 -1.31342,-0.810777 -0.59926,-0.638753 -0.98336,-1.311365 -0.85833,-1.502183 l 18.114,-27.584192"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       transform="matrix(0.56847789,-0.86569398,0.67965706,0.72408265,0,0)"
+       
+       x="90.355705"
+       y="181.1127"
+       >App<tspan
+   font-size="2.92393px"
+   x="95.167725"
+   y="181.11955"
+   
+   >-</tspan><tspan
+   font-size="2.92393px"
+   x="96.021591"
+   y="181.14969"
+   
+   >2</tspan></text>
+    <path
+       d="M 21.907209,68.558901 H 43.517623"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 166.6525,68.558901 h 21.61041"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="53.221756"
+       y="40.868256"
+       width="17.121622"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.03404px"
+       
+       x="63.280228"
+       y="39.38987"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="2.03404px"
+   x="69.546547"
+   y="39.38987"
+   
+   >F</tspan><tspan
+   font-size="2.03404px"
+   x="70.621819"
+   y="39.38987"
+   
+   >-</tspan><tspan
+   font-size="2.03404px"
+   x="71.474625"
+   y="39.38987"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="66.747826"
+   y="41.932407"
+   
+   >20000</tspan></text>
+    <rect
+       x="61.782566"
+       y="32.546707"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.52553px"
+       
+       x="72.58696"
+       y="30.872347"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="1.52553px"
+   x="72.142006"
+   y="32.652126"
+   
+   >S</tspan><tspan
+   font-size="1.52553px"
+   x="72.994812"
+   y="32.652126"
+   
+   >-</tspan><tspan
+   font-size="1.52553px"
+   x="73.625145"
+   y="32.652126"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="72.790146"
+   y="35.067543"
+   
+   >103</tspan></text>
+    <rect
+       x="53.221756"
+       y="32.546707"
+       width="8.560833"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.52553px"
+       
+       x="62.894905"
+       y="30.872347"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="1.52553px"
+   x="62.449959"
+   y="32.652126"
+   
+   >S</tspan><tspan
+   font-size="1.52553px"
+   x="63.302757"
+   y="32.652126"
+   
+   >-</tspan><tspan
+   font-size="1.52553px"
+   x="63.933098"
+   y="32.652126"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="63.098099"
+   y="35.067543"
+   
+   >100</tspan></text>
+    <rect
+       x="53.221756"
+       y="24.225159"
+       width="8.560833"
+       height="8.3215294"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.65265px"
+       
+       x="64.11927"
+       y="23.880342"
+       
+       transform="scale(0.88605917,1.1285928)">IP<tspan
+   font-size="1.65265px"
+   x="62.283131"
+   y="25.787251"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.65265px"
+   x="62.283131"
+   y="27.69416"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="61.782566"
+       y="24.225159"
+       width="8.560811"
+       height="8.3215294"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.65265px"
+       
+       x="73.81131"
+       y="23.880342"
+       
+       transform="scale(0.88605917,1.1285928)">IP<tspan
+   font-size="1.65265px"
+   x="71.975174"
+   y="25.787251"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.65265px"
+   x="71.975174"
+   y="27.69416"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="53.221756"
+       y="15.903621"
+       width="8.560833"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.77978px"
+       
+       x="62.431393"
+       y="17.396856"
+       
+       transform="scale(0.88605917,1.1285928)">DATA <tspan
+   font-size="1.77978px"
+   x="64.359505"
+   y="19.558016"
+   
+   >1</tspan></text>
+    <rect
+       x="61.782566"
+       y="15.903621"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.77978px"
+       
+       x="72.123436"
+       y="17.396856"
+       
+       transform="scale(0.88605917,1.1285928)">DATA <tspan
+   font-size="1.77978px"
+   x="74.051537"
+   y="19.558016"
+   
+   >2</tspan></text>
+    <rect
+       x="7.2637129"
+       y="55.21574"
+       width="17.121622"
+       height="8.3215294"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="12.766096"
+       y="52.483971"
+       
+       transform="scale(0.88605917,1.1285928)">IP <tspan
+   font-size="2.03404px"
+   x="16.548124"
+   y="52.483971"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="2.03404px"
+   x="16.511055"
+   y="55.153641"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="81.945526"
+       y="40.868256"
+       width="17.121622"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.03404px"
+       
+       x="95.751953"
+       y="39.38987"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="2.03404px"
+   x="102.01825"
+   y="39.38987"
+   
+   >F</tspan><tspan
+   font-size="2.03404px"
+   x="103.09354"
+   y="39.38987"
+   
+   >-</tspan><tspan
+   font-size="2.03404px"
+   x="103.94636"
+   y="39.38987"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="99.219559"
+   y="41.932407"
+   
+   >20001</tspan></text>
+    <rect
+       x="82.508736"
+       y="112.17525"
+       width="17.00898"
+       height="8.4650326"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.03404px"
+       
+       x="96.259819"
+       y="102.69923"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="2.03404px"
+   x="102.52615"
+   y="102.69923"
+   
+   >F</tspan><tspan
+   font-size="2.03404px"
+   x="103.60142"
+   y="102.69923"
+   
+   >-</tspan><tspan
+   font-size="2.03404px"
+   x="104.45422"
+   y="102.69923"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="99.727432"
+   y="105.24178"
+   
+   >20002</tspan></text>
+    <rect
+       x="81.945526"
+       y="32.546707"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.52553px"
+       
+       x="95.360779"
+       y="30.872347"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="1.52553px"
+   x="94.915825"
+   y="32.652126"
+   
+   >S</tspan><tspan
+   font-size="1.52553px"
+   x="95.768654"
+   y="32.652126"
+   
+   >-</tspan><tspan
+   font-size="1.52553px"
+   x="96.398987"
+   y="32.652126"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="95.563988"
+   y="35.067543"
+   
+   >101</tspan></text>
+    <rect
+       x="81.945526"
+       y="24.225159"
+       width="8.560811"
+       height="8.3215294"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.65265px"
+       
+       x="96.585136"
+       y="23.880342"
+       
+       transform="scale(0.88605917,1.1285928)">IP<tspan
+   font-size="1.65265px"
+   x="94.748985"
+   y="25.787251"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.65265px"
+   x="94.748985"
+   y="27.69416"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="81.945526"
+       y="15.903621"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.77978px"
+       
+       x="94.8974"
+       y="17.396856"
+       
+       transform="scale(0.88605917,1.1285928)">DATA <tspan
+   font-size="1.77978px"
+   x="96.825508"
+   y="19.558016"
+   
+   >1</tspan></text>
+    <rect
+       x="90.50634"
+       y="32.546707"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.52553px"
+       
+       x="105.04189"
+       y="30.872347"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="1.52553px"
+   x="104.59696"
+   y="32.652126"
+   
+   >S</tspan><tspan
+   font-size="1.52553px"
+   x="105.44977"
+   y="32.652126"
+   
+   >-</tspan><tspan
+   font-size="1.52553px"
+   x="106.0801"
+   y="32.652126"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="105.2451"
+   y="35.067543"
+   
+   >104</tspan></text>
+    <rect
+       x="90.50634"
+       y="24.225159"
+       width="8.560811"
+       height="8.3215294"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.65265px"
+       
+       x="106.26627"
+       y="23.880342"
+       
+       transform="scale(0.88605917,1.1285928)">IP<tspan
+   font-size="1.65265px"
+   x="104.43011"
+   y="25.787251"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.65265px"
+   x="104.43011"
+   y="27.69416"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="90.50634"
+       y="15.903621"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.77978px"
+       
+       x="104.57839"
+       y="17.396856"
+       
+       transform="scale(0.88605917,1.1285928)">DATA <tspan
+   font-size="1.77978px"
+   x="106.50649"
+   y="19.558016"
+   
+   >2</tspan></text>
+    <rect
+       x="82.508736"
+       y="103.9972"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.52553px"
+       
+       x="95.916458"
+       y="94.181694"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="1.52553px"
+   x="95.471504"
+   y="95.961479"
+   
+   >S</tspan><tspan
+   font-size="1.52553px"
+   x="96.324326"
+   y="95.961479"
+   
+   >-</tspan><tspan
+   font-size="1.52553px"
+   x="96.954659"
+   y="95.961479"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="96.119644"
+   y="98.376907"
+   
+   >101</tspan></text>
+    <rect
+       x="90.956902"
+       y="103.9972"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.52553px"
+       
+       x="105.49943"
+       y="94.181694"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="1.52553px"
+   x="105.05449"
+   y="95.961479"
+   
+   >S</tspan><tspan
+   font-size="1.52553px"
+   x="105.9073"
+   y="95.961479"
+   
+   >-</tspan><tspan
+   font-size="1.52553px"
+   x="106.53764"
+   y="95.961479"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="105.70261"
+   y="98.376907"
+   
+   >104</tspan></text>
+    <rect
+       x="82.508736"
+       y="95.675652"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.65265px"
+       
+       x="97.140808"
+       y="87.189705"
+       
+       transform="scale(0.88605917,1.1285928)">IP<tspan
+   font-size="1.65265px"
+   x="95.304665"
+   y="89.096611"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.65265px"
+   x="95.304665"
+   y="91.003517"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="90.956902"
+       y="95.675652"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.65265px"
+       
+       x="106.72378"
+       y="87.189705"
+       
+       transform="scale(0.88605917,1.1285928)">IP<tspan
+   font-size="1.65265px"
+   x="104.88765"
+   y="89.096611"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.65265px"
+   x="104.88765"
+   y="91.003517"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="82.508736"
+       y="87.354103"
+       width="8.560811"
+       height="8.465004"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.77978px"
+       
+       x="95.452934"
+       y="80.833336"
+       
+       transform="scale(0.88605917,1.1285928)">DATA <tspan
+   font-size="1.77978px"
+   x="97.38105"
+   y="82.994499"
+   
+   >1</tspan></text>
+    <rect
+       x="90.956902"
+       y="87.354103"
+       width="8.560811"
+       height="8.465004"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.77978px"
+       
+       x="105.03593"
+       y="80.833336"
+       
+       transform="scale(0.88605917,1.1285928)">DATA <tspan
+   font-size="1.77978px"
+   x="106.96404"
+   y="82.994499"
+   
+   >2</tspan></text>
+    <rect
+       x="111.23251"
+       y="40.868256"
+       width="17.121622"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.03404px"
+       
+       x="128.77415"
+       y="39.38987"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="2.03404px"
+   x="135.04045"
+   y="39.38987"
+   
+   >F</tspan><tspan
+   font-size="2.03404px"
+   x="136.11572"
+   y="39.38987"
+   
+   >-</tspan><tspan
+   font-size="2.03404px"
+   x="136.96855"
+   y="39.38987"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="132.24174"
+   y="41.932407"
+   
+   >20003</tspan></text>
+    <rect
+       x="111.45779"
+       y="112.17525"
+       width="17.121622"
+       height="8.4650326"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.03404px"
+       
+       x="129.00552"
+       y="102.69923"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="2.03404px"
+   x="135.27182"
+   y="102.69923"
+   
+   >F</tspan><tspan
+   font-size="2.03404px"
+   x="136.34711"
+   y="102.69923"
+   
+   >-</tspan><tspan
+   font-size="2.03404px"
+   x="137.19992"
+   y="102.69923"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="132.47313"
+   y="105.24178"
+   
+   >20004</tspan></text>
+    <rect
+       x="119.79331"
+       y="32.546707"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.52553px"
+       
+       x="138.07857"
+       y="30.872347"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="1.52553px"
+   x="137.63364"
+   y="32.652126"
+   
+   >S</tspan><tspan
+   font-size="1.52553px"
+   x="138.48643"
+   y="32.652126"
+   
+   >-</tspan><tspan
+   font-size="1.52553px"
+   x="139.11679"
+   y="32.652126"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="138.28177"
+   y="35.067543"
+   
+   >104</tspan></text>
+    <rect
+       x="111.23251"
+       y="32.546707"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.52553px"
+       
+       x="128.36861"
+       y="30.872347"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="1.52553px"
+   x="127.92366"
+   y="32.652126"
+   
+   >S</tspan><tspan
+   font-size="1.52553px"
+   x="128.77647"
+   y="32.652126"
+   
+   >-</tspan><tspan
+   font-size="1.52553px"
+   x="129.40681"
+   y="32.652126"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="128.57181"
+   y="35.067543"
+   
+   >101</tspan></text>
+    <rect
+       x="111.23251"
+       y="24.225159"
+       width="8.560811"
+       height="8.3215294"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.65265px"
+       
+       x="129.5941"
+       y="23.880342"
+       
+       transform="scale(0.88605917,1.1285928)">IP<tspan
+   font-size="1.65265px"
+   x="127.75799"
+   y="25.787251"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.65265px"
+   x="127.75799"
+   y="27.69416"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="119.79331"
+       y="24.225159"
+       width="8.560811"
+       height="8.3215294"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.65265px"
+       
+       x="139.30283"
+       y="23.880342"
+       
+       transform="scale(0.88605917,1.1285928)">IP<tspan
+   font-size="1.65265px"
+   x="137.46666"
+   y="25.787251"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.65265px"
+   x="137.46666"
+   y="27.69416"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="111.23251"
+       y="15.903621"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.77978px"
+       
+       x="127.90585"
+       y="17.396856"
+       
+       transform="scale(0.88605917,1.1285928)">DATA <tspan
+   font-size="1.77978px"
+   x="129.83395"
+   y="19.558016"
+   
+   >1</tspan></text>
+    <rect
+       x="119.79331"
+       y="15.903621"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.77978px"
+       
+       x="137.61456"
+       y="17.396856"
+       
+       transform="scale(0.88605917,1.1285928)">DATA <tspan
+   font-size="1.77978px"
+   x="139.54266"
+   y="19.558016"
+   
+   >2</tspan></text>
+    <rect
+       x="111.45779"
+       y="103.9972"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.52553px"
+       
+       x="128.59488"
+       y="94.181694"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="1.52553px"
+   x="128.14993"
+   y="95.961479"
+   
+   >S</tspan><tspan
+   font-size="1.52553px"
+   x="129.00275"
+   y="95.961479"
+   
+   >-</tspan><tspan
+   font-size="1.52553px"
+   x="129.6331"
+   y="95.961479"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="128.7981"
+   y="98.376907"
+   
+   >101</tspan></text>
+    <rect
+       x="120.01861"
+       y="103.9972"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.52553px"
+       
+       x="138.31503"
+       y="94.181694"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="1.52553px"
+   x="137.8701"
+   y="95.961479"
+   
+   >S</tspan><tspan
+   font-size="1.52553px"
+   x="138.7229"
+   y="95.961479"
+   
+   >-</tspan><tspan
+   font-size="1.52553px"
+   x="139.35326"
+   y="95.961479"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="138.51823"
+   y="98.376907"
+   
+   >104</tspan></text>
+    <rect
+       x="111.45779"
+       y="95.675652"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.65265px"
+       
+       x="129.81914"
+       y="87.189705"
+       
+       transform="scale(0.88605917,1.1285928)">IP<tspan
+   font-size="1.65265px"
+   x="127.98296"
+   y="89.096611"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.65265px"
+   x="127.98296"
+   y="91.003517"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="120.01861"
+       y="95.675652"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.65265px"
+       
+       x="139.53928"
+       y="87.189705"
+       
+       transform="scale(0.88605917,1.1285928)">IP<tspan
+   font-size="1.65265px"
+   x="137.70311"
+   y="89.096611"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.65265px"
+   x="137.70311"
+   y="91.003517"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="111.45779"
+       y="87.354103"
+       width="8.560811"
+       height="8.465004"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.77978px"
+       
+       x="128.13214"
+       y="80.833336"
+       
+       transform="scale(0.88605917,1.1285928)">DATA <tspan
+   font-size="1.77978px"
+   x="130.06023"
+   y="82.994499"
+   
+   >1</tspan></text>
+    <rect
+       x="120.01861"
+       y="87.354103"
+       width="8.560811"
+       height="8.465004"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.77978px"
+       
+       x="137.85101"
+       y="80.833336"
+       
+       transform="scale(0.88605917,1.1285928)">DATA <tspan
+   font-size="1.77978px"
+   x="139.77911"
+   y="82.994499"
+   
+   >2</tspan></text>
+    <rect
+       x="140.18156"
+       y="40.868256"
+       width="17.234264"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.03404px"
+       
+       x="161.49542"
+       y="39.38987"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="2.03404px"
+   x="167.76172"
+   y="39.38987"
+   
+   >F</tspan><tspan
+   font-size="2.03404px"
+   x="168.83702"
+   y="39.38987"
+   
+   >-</tspan><tspan
+   font-size="2.03404px"
+   x="169.68983"
+   y="39.38987"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="164.96303"
+   y="41.932407"
+   
+   >20005</tspan></text>
+    <rect
+       x="148.85503"
+       y="32.546707"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.52553px"
+       
+       x="170.80495"
+       y="30.872347"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="1.52553px"
+   x="170.36002"
+   y="32.652126"
+   
+   >S</tspan><tspan
+   font-size="1.52553px"
+   x="171.2128"
+   y="32.652126"
+   
+   >-</tspan><tspan
+   font-size="1.52553px"
+   x="171.84315"
+   y="32.652126"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="171.00812"
+   y="35.067543"
+   
+   >105</tspan></text>
+    <rect
+       x="140.18156"
+       y="32.546707"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.52553px"
+       
+       x="161.08479"
+       y="30.872347"
+       
+       transform="scale(0.88605917,1.1285928)">MPLS<tspan
+   font-size="1.52553px"
+   x="160.63986"
+   y="32.652126"
+   
+   >S</tspan><tspan
+   font-size="1.52553px"
+   x="161.49266"
+   y="32.652126"
+   
+   >-</tspan><tspan
+   font-size="1.52553px"
+   x="162.123"
+   y="32.652126"
+   
+   >label</tspan><tspan
+   font-size="2.03404px"
+   x="161.28798"
+   y="35.067543"
+   
+   >102</tspan></text>
+    <rect
+       x="140.18156"
+       y="24.225159"
+       width="8.560811"
+       height="8.3215294"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.65265px"
+       
+       x="162.30902"
+       y="23.880342"
+       
+       transform="scale(0.88605917,1.1285928)">IP<tspan
+   font-size="1.65265px"
+   x="160.47287"
+   y="25.787251"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.65265px"
+   x="160.47287"
+   y="27.69416"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="148.85503"
+       y="24.225159"
+       width="8.560811"
+       height="8.3215294"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.65265px"
+       
+       x="172.02917"
+       y="23.880342"
+       
+       transform="scale(0.88605917,1.1285928)">IP<tspan
+   font-size="1.65265px"
+   x="170.19304"
+   y="25.787251"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.65265px"
+   x="170.19304"
+   y="27.69416"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="140.18156"
+       y="15.903621"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.77978px"
+       
+       x="160.62077"
+       y="17.396856"
+       
+       transform="scale(0.88605917,1.1285928)">DATA <tspan
+   font-size="1.77978px"
+   x="162.54887"
+   y="19.558016"
+   
+   >1</tspan></text>
+    <rect
+       x="148.85503"
+       y="15.903621"
+       width="8.560811"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.77978px"
+       
+       x="170.34221"
+       y="17.396856"
+       
+       transform="scale(0.88605917,1.1285928)">DATA <tspan
+   font-size="1.77978px"
+   x="172.27031"
+   y="19.558016"
+   
+   >2</tspan></text>
+    <rect
+       x="186.02696"
+       y="55.359215"
+       width="17.00898"
+       height="8.1780396"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="214.42229"
+       y="52.611099"
+       
+       transform="scale(0.88605917,1.1285928)">IP <tspan
+   font-size="2.03404px"
+   x="218.20433"
+   y="52.611099"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="2.03404px"
+   x="218.16727"
+   y="55.280769"
+   
+   >192.0.2.88</tspan></text>
+    <path
+       d="m 71.258592,76.450018 c -0.863177,0 -1.562909,-3.565065 -1.562909,-7.962853 0,-4.397793 0.699732,-7.962858 1.562909,-7.962858 0.863176,0 1.56291,3.565065 1.56291,7.962858 0,4.397788 -0.699734,7.962853 -1.56291,7.962853 h -16.02336 c -0.863177,0 -1.56291,-3.565065 -1.56291,-7.962853 0,-4.397793 0.699733,-7.962858 1.56291,-7.962858 h 16.02336"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="63.679035"
+       y="63.925423"
+       
+       transform="scale(0.88605917,1.1285928)">DN-1 / DN-2</text>
+    <path
+       d="m 52.954228,68.27195 c -0.396615,0 -0.718095,-1.702188 -0.718095,-3.802085 0,-2.099897 0.32148,-3.802086 0.718095,-3.802086 0.396614,0 0.718094,1.702189 0.718094,3.802086 0,2.099897 -0.32148,3.802085 -0.718094,3.802085 h -4.308566 c -0.396614,0 -0.718095,-1.702188 -0.718095,-3.802085 0,-2.099897 0.321481,-3.802086 0.718095,-3.802086 h 4.308566"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="54.603413"
+       y="57.187675"
+       
+       transform="scale(0.88605917,1.1285928)">DN-2</text>
+    <path
+       d="m 52.841587,76.593491 c -0.396615,0 -0.718095,-1.734322 -0.718095,-3.873822 0,-2.139493 0.32148,-3.873821 0.718095,-3.873821 0.39661,0 0.71809,1.734328 0.71809,3.873821 0,2.1395 -0.32148,3.873822 -0.71809,3.873822 h -4.308569 c -0.39661,0 -0.718095,-1.734322 -0.718095,-3.873822 0,-2.139493 0.321485,-3.873821 0.718095,-3.873821 h 4.308569"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="54.392769"
+       y="66.976471"
+       
+       transform="scale(0.88605917,1.1285928)">DN-1</text>
+    <path
+       d="m 78.819704,68.27195 c -0.419931,0 -0.760335,-1.734322 -0.760335,-3.873822 0,-2.139499 0.340404,-3.873821 0.760335,-3.873821 0.419928,0 0.760332,1.734322 0.760332,3.873821 0,2.1395 -0.340404,3.873822 -0.760332,3.873822 h -5.463152 c -0.419927,0 -0.760332,-1.734322 -0.760332,-3.873822 0,-2.139499 0.340405,-3.873821 0.760332,-3.873821 h 5.463152"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="82.416687"
+       y="56.93343"
+       
+       transform="scale(0.88605917,1.1285928)">DN-2</text>
+    <path
+       d="m 78.594419,76.593491 c -0.419933,0 -0.760337,-1.734322 -0.760337,-3.873822 0,-2.139493 0.340404,-3.873821 0.760337,-3.873821 0.419931,0 0.760336,1.734328 0.760336,3.873821 0,2.1395 -0.340405,3.873822 -0.760336,3.873822 h -5.350508 c -0.419931,0 -0.760336,-1.734322 -0.760336,-3.873822 0,-2.139493 0.340405,-3.873821 0.760336,-3.873821 h 5.350508"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="82.064415"
+       y="66.976471"
+       
+       transform="scale(0.88605917,1.1285928)">DN-1</text>
+    <path
+       d="m 155.0785,76.450018 c -0.85495,0 -1.54882,-3.532925 -1.54882,-7.891117 0,-4.358196 0.69387,-7.891122 1.54882,-7.891122 0.85495,0 1.54883,3.532926 1.54883,7.891122 0,4.358192 -0.69388,7.891117 -1.54883,7.891117 h -15.71359 c -0.85496,0 -1.54883,-3.532925 -1.54883,-7.891117 0,-4.358196 0.69387,-7.891122 1.54883,-7.891122 h 15.71359"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="158.66682"
+       y="63.925423"
+       
+       transform="scale(0.88605917,1.1285928)">DN-1 / DN-2</text>
+    <path
+       d="m 161.33015,68.415423 c -0.38862,0 -0.70402,-1.734322 -0.70402,-3.873821 0,-2.139495 0.3154,-3.873823 0.70402,-3.873823 0.38862,0 0.70402,1.734328 0.70402,3.873823 0,2.139499 -0.3154,3.873821 -0.70402,3.873821 h -4.22409 c -0.38861,0 -0.70401,-1.734322 -0.70401,-3.873821 0,-2.139495 0.3154,-3.873823 0.70401,-3.873823 h 4.22409"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="176.71127"
+       y="56.552044"
+       
+       transform="scale(0.88605917,1.1285928)">DN-2</text>
+    <path
+       d="m 161.20399,76.593491 c -0.39763,0 -0.71866,-1.734322 -0.71866,-3.873822 0,-2.139493 0.32103,-3.873821 0.71866,-3.873821 0.3965,0 0.71753,1.734328 0.71753,3.873821 0,2.1395 -0.32103,3.873822 -0.71753,3.873822 h -4.30856 c -0.39763,0 -0.71867,-1.734322 -0.71867,-3.873822 0,-2.139493 0.32104,-3.873821 0.71867,-3.873821 h 4.30856"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="176.83078"
+       y="66.595085"
+       
+       transform="scale(0.88605917,1.1285928)">DN-1</text>
+    <path
+       d="m 129.28343,76.450018 c -0.85495,0 -1.54883,-3.532925 -1.54883,-7.891117 0,-4.358196 0.69388,-7.891122 1.54883,-7.891122 0.85495,0 1.54883,3.532926 1.54883,7.891122 0,4.358192 -0.69388,7.891117 -1.54883,7.891117 H 81.579439 c -0.855407,0 -1.548831,-3.532925 -1.548831,-7.891117 0,-4.358196 0.693424,-7.891122 1.548831,-7.891122 h 47.703991"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="112.44083"
+       y="61.891384"
+       
+       transform="scale(0.88605917,1.1285928)">DN-1 / DN-2</text>
+    <path
+       d="m 136.71782,76.593491 c -0.42016,0 -0.76034,-1.734322 -0.76034,-3.873822 0,-2.139493 0.34018,-3.873821 0.76034,-3.873821 0.42015,0 0.76033,1.734328 0.76033,3.873821 0,2.1395 -0.34018,3.873822 -0.76033,3.873822 h -5.35051 c -0.42016,0 -0.76033,-1.734322 -0.76033,-3.873822 0,-2.139493 0.34017,-3.873821 0.76033,-3.873821 h 5.35051"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="147.60677"
+       y="66.467972"
+       
+       transform="scale(0.88605917,1.1285928)">DN-1</text>
+    <rect
+       x="7.2637129"
+       y="47.037678"
+       width="17.121622"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="12.432393"
+       y="46.508987"
+       
+       transform="scale(0.88605917,1.1285928)">DATA 1</text>
+    <rect
+       x="186.02696"
+       y="47.037678"
+       width="17.00898"
+       height="8.321557"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="214.08922"
+       y="46.508987"
+       
+       transform="scale(0.88605917,1.1285928)">DATA 1</text>
+    <path
+       d="m 42.056089,70.2806 c -0.19442,0 -0.352006,-0.802886 -0.352006,-1.793435 0,-0.990554 0.157586,-1.793441 0.352006,-1.793441 0.19442,0 0.352006,0.802887 0.352006,1.793441 0,0.990549 -0.157586,1.793435 -0.352006,1.793435 H 22.935068 c -0.19442,0 -0.352006,-0.802886 -0.352006,-1.793435 0,-0.990554 0.157586,-1.793441 0.352006,-1.793441 h 19.121021"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="33.60886"
+       y="65.450958"
+       
+       transform="scale(0.88605917,1.1285928)">App-1</text>
+    <path
+       d="m 186.80193,70.424073 c -0.19487,0 -0.35256,-0.802886 -0.35256,-1.793435 0,-0.990548 0.15769,-1.793435 0.35256,-1.793435 0.19376,0 0.35145,0.802887 0.35145,1.793435 0,0.990549 -0.15769,1.793435 -0.35145,1.793435 h -19.0095 c -0.19374,0 -0.35144,-0.802886 -0.35144,-1.793435 0,-0.990548 0.1577,-1.793435 0.35144,-1.793435 h 19.0095"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="196.88129"
+       y="65.450958"
+       
+       transform="scale(0.88605917,1.1285928)">App-1<tspan
+   font-size="4.1952px"
+   x="181.19646"
+   y="84.901405"
+   
+   >Note: S-label in this</tspan><tspan
+   font-size="4.1952px"
+   x="181.19646"
+   y="89.859375"
+   
+   >diagram includes d-CW.</tspan></text>
+    <path
+       d="m 74.511135,36.707479 c 0,-1.980957 1.235575,-3.586871 2.759739,-3.586871 1.524159,0 2.759734,1.605914 2.759734,3.586871 0,1.980956 -1.235575,3.58687 -2.759734,3.58687 -1.524164,0 -2.759739,-1.605914 -2.759739,-3.58687 z"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.33934px"
+       
+       x="85.55648"
+       y="34.559036"
+       
+       transform="scale(0.88605917,1.1285928)">R</text>
+    <path
+       d="m 130.04376,36.707479 c 0,-1.980957 1.23568,-3.586871 2.75974,-3.586871 1.52405,0 2.75974,1.605914 2.75974,3.586871 0,1.980956 -1.23569,3.58687 -2.75974,3.58687 -1.52406,0 -2.75974,-1.605914 -2.75974,-3.58687 z"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.33934px"
+       
+       x="148.49284"
+       y="34.559036"
+       
+       transform="scale(0.88605917,1.1285928)">E</text>
+    <path
+       d="m 74.511135,108.15797 c 0,-1.98097 1.235575,-3.58688 2.759739,-3.58688 1.524159,0 2.759734,1.60591 2.759734,3.58688 0,1.98095 -1.235575,3.58686 -2.759734,3.58686 -1.524164,0 -2.759739,-1.60591 -2.759739,-3.58686 z"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.33934px"
+       
+       x="85.55648"
+       y="97.868401"
+       
+       transform="scale(0.88605917,1.1285928)">R</text>
+    <path
+       d="m 130.04376,108.15797 c 0,-1.98097 1.23568,-3.58688 2.75974,-3.58688 1.52405,0 2.75974,1.60591 2.75974,3.58688 0,1.98095 -1.23569,3.58686 -2.75974,3.58686 -1.52406,0 -2.75974,-1.60591 -2.75974,-3.58686 z"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.33934px"
+       
+       x="148.49284"
+       y="97.868401"
+       
+       transform="scale(0.88605917,1.1285928)">E</text>
+    <path
+       d="m 40.211573,59.51826 c 0,-0.355527 0.2263,-0.643915 0.505539,-0.643915 h 14.646194 c 0.279243,0 0.505538,0.288388 0.505538,0.643915 v 19.802977 c 0,0.355673 -0.226295,0.643915 -0.505538,0.643915 H 40.717112 c -0.279239,0 -0.505539,-0.288242 -0.505539,-0.643915 z"
+       stroke="#000000"
+       stroke-width="0.59326"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.37305, 1.77978"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 153.8676,59.550688 c 0,-0.373465 0.23767,-0.676343 0.53054,-0.676343 h 15.38468 c 0.29288,0 0.53055,0.302878 0.53055,0.676343 v 19.738126 c 0,0.373466 -0.23767,0.676338 -0.53055,0.676338 h -15.38468 c -0.29287,0 -0.53054,-0.302872 -0.53054,-0.676338 z"
+       stroke="#000000"
+       stroke-width="0.59326"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.37305, 1.77978"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="47.073029"
+       y="77.52803"
+       
+       transform="scale(0.88605917,1.1285928)">aggregation<tspan
+   font-size="2.92393px"
+   x="175.10539"
+   y="77.655159"
+   
+   >disaggregation</tspan></text>
+    <path
+       d="m 137.25287,65.406306 c 0,-0.398322 -0.25351,-0.721226 -0.56624,-0.721226 h -6.18927 c -0.31274,0 -0.56624,0.322904 -0.56624,0.721226 v 6.305186 c 0,0.398327 0.2535,0.721232 0.56624,0.721232 h 6.18927 c 0.31273,0 0.56624,-0.322905 0.56624,-0.721232 z"
+       stroke="#000000"
+       stroke-width="0.29663"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 136.15995,65.115504 v 0.83538 h -1.52854 l -0.81413,1.874515 -0.83073,-1.874515 h -1.51196 v -0.83538 l -0.98027,1.059504 0.98027,1.059504 v -0.713126 h 1.07997 l 0.93042,2.057888 -0.93042,2.078261 h -1.07997 v -0.774243 l -0.98027,1.059504 0.98027,1.059503 v -0.794633 h 1.51196 l 0.83073,-1.915261 0.81413,1.915261 h 1.52854 v 0.753887 l 0.98027,-1.018757 -0.98027,-1.059504 v 0.774243 h -1.06333 l -0.94705,-2.078261 0.93043,-2.057888 h 1.07995 v 0.692753 l 0.98027,-1.039131 z"
+       stroke="#000000"
+       stroke-width="0.222473"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.92393px"
+       
+       x="81.274445"
+       y="70.663162"
+       
+       transform="scale(0.88605917,1.1285928)">Relay 1<tspan
+   font-size="2.92393px"
+   x="81.459839"
+   y="73.58709"
+   
+   >192.0.2.3</tspan></text>
+  </g>
+</svg>
+</artwork>
+</artset>
+        </figure>
+        <figure anchor="example-detnet-xml-fwd-aggregation-b-1">
+          <name>Example B-1 DetNet XML configuration</name>
+          <artwork name="" type="" align="left" alt=""><![CDATA[
+<interfaces
+  xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces"
+  xmlns:ia="urn:ietf:params:xml:ns:yang:iana-if-type">
+    <interface>
+      <name>eth0</name>
+      <type>ia:ethernetCsmacd</type>
+      <oper-status>up</oper-status>
+      <statistics>
+         <discontinuity-time>2020-12-18T23:59:00Z</discontinuity-time>
+      </statistics>
+    </interface>
+    <interface>
+      <name>eth1</name>
+      <type>ia:ethernetCsmacd</type>
+      <oper-status>up</oper-status>
+      <statistics>
+         <discontinuity-time>2020-12-18T23:59:00Z</discontinuity-time>
+      </statistics>
+    </interface>
+    <interface>
+      <name>eth2</name>
+      <type>ia:ethernetCsmacd</type>
+      <oper-status>up</oper-status>
+      <statistics>
+         <discontinuity-time>2020-12-18T23:59:00Z</discontinuity-time>
+      </statistics>
+    </interface>
+    <interface>
+      <name>eth3</name>
+      <type>ia:ethernetCsmacd</type>
+      <oper-status>up</oper-status>
+      <statistics>
+         <discontinuity-time>2020-12-18T23:59:00Z</discontinuity-time>
+      </statistics>
+    </interface>
+    <interface>
+      <name>eth4</name>
+      <type>ia:ethernetCsmacd</type>
+      <oper-status>up</oper-status>
+      <statistics>
+         <discontinuity-time>2020-12-18T23:59:00Z</discontinuity-time>
+      </statistics>
+    </interface>
+  </interfaces>
+<detnet
+  xmlns="urn:ietf:params:xml:ns:yang:ietf-detnet">
+  <app-flows>
+    <app-flow>
+      <name>app-1</name>
+      <app-flow-bidir-congruent>false</app-flow-bidir-congruent>
+      <outgoing-service>ssl-1</outgoing-service>
+       <traffic-profile>1</traffic-profile>
+      <ingress>
+        <app-flow-status>ready</app-flow-status>
+        <interface>eth0</interface>
+        <ip-app-flow>
+          <src-ip-prefix>192.0.2.1/32</src-ip-prefix>
+          <dest-ip-prefix>192.0.2.88/32</dest-ip-prefix>
+          <dscp>6</dscp>
+        </ip-app-flow>
+      </ingress>
+    </app-flow>
+    <app-flow>
+      <name>app-2</name>
+      <app-flow-bidir-congruent>false</app-flow-bidir-congruent>
+      <outgoing-service>ssl-2</outgoing-service>
+       <traffic-profile>1</traffic-profile>
+      <ingress>
+        <app-flow-status>ready</app-flow-status>
+        <interface>eth1</interface>
+        <ip-app-flow>
+          <src-ip-prefix>192.0.2.12/32</src-ip-prefix>
+          <dest-ip-prefix>192.0.2.89/32</dest-ip-prefix>
+          <dscp>7</dscp>
+        </ip-app-flow>
+        <dscp>7</dscp>
+      </ingress>
+    </app-flow>
+  </app-flows>
+  <traffic-profile>  
+    <profile-name>1</profile-name>
+    <traffic-requirements>
+      <min-bandwidth>100000000</min-bandwidth>
+      <max-latency>100000000</max-latency>
+      <max-latency-variation>200000000</max-latency-variation>
+      <max-loss>2</max-loss>
+      <max-consecutive-loss-tolerance>5</max-consecutive-loss-tolerance>
+      <max-misordering>0</max-misordering>
+    </traffic-requirements>
+    <member-apps>app-1</member-apps>
+    <member-apps>app-2</member-apps>
+  </traffic-profile>
+  <traffic-profile>  
+    <profile-name>2</profile-name>
+    <traffic-requirements>
+      <min-bandwidth>100000000</min-bandwidth>
+      <max-latency>100000000</max-latency>
+      <max-latency-variation>200000000</max-latency-variation>
+      <max-loss>2</max-loss>
+      <max-consecutive-loss-tolerance>5</max-consecutive-loss-tolerance>
+      <max-misordering>0</max-misordering>
+    </traffic-requirements>
+    <member-services>ssl-1</member-services>
+    <member-services>ssl-2</member-services>
+  </traffic-profile>
+  <traffic-profile>  
+    <profile-name>3</profile-name>
+    <flow-spec>
+      <interval>5</interval>
+      <max-pkts-per-interval>10</max-pkts-per-interval>
+      <max-payload-size>1500</max-payload-size>
+    </flow-spec>
+    <member-fwd-sublayers>afl-1</member-fwd-sublayers>
+  </traffic-profile>
+  <service-sub-layer>
+    <service-sub-layer-list>
+      <name>ssl-1</name>
+      <service-rank>10</service-rank>
+      <traffic-profile>2</traffic-profile>
+      <service-operation-type>service-initiation
+      </service-operation-type>
+      <service-protection>
+        <service-protection-type>none</service-protection-type>
+        <sequence-number-length>long-sn</sequence-number-length>
+      </service-protection>
+     <incoming-type>
+        <app-flow>
+          <app-flow-list>app-1</app-flow-list>
+        </app-flow>
+      </incoming-type>
+      <outgoing-type>
+        <forwarding-sub-layer>
+          <service-outgoing-list>
+            <service-outgoing-index>0</service-outgoing-index>
+            <mpls-label-stack>
+              <entry>
+                <id>0</id>
+                <label>100</label>
+              </entry>
+            </mpls-label-stack>
+            <forwarding-sub-layer>afl-1</forwarding-sub-layer>
+          </service-outgoing-list>
+         </forwarding-sub-layer>
+      </outgoing-type>
+    </service-sub-layer-list>
+    <service-sub-layer-list>
+      <name>ssl-2</name>
+      <service-rank>10</service-rank>
+      <traffic-profile>2</traffic-profile>
+      <service-operation-type>service-initiation
+      </service-operation-type>
+      <service-protection>
+        <service-protection-type>none</service-protection-type>
+        <sequence-number-length>long-sn</sequence-number-length>
+      </service-protection>
+     <incoming-type>
+        <app-flow>
+          <app-flow-list>app-2</app-flow-list>
+        </app-flow>
+      </incoming-type>
+      <outgoing-type>
+        <forwarding-sub-layer>
+          <service-outgoing-list>
+            <service-outgoing-index>0</service-outgoing-index>
+            <mpls-label-stack>
+              <entry>
+                <id>0</id>
+                <label>103</label>
+              </entry>
+            </mpls-label-stack>
+            <forwarding-sub-layer>afl-1</forwarding-sub-layer>
+          </service-outgoing-list>
+         </forwarding-sub-layer>
+      </outgoing-type>
+    </service-sub-layer-list>
+    </service-sub-layer>  
+    <forwarding-sub-layer>
+    <forwarding-sub-layer-list>
+      <name>afl-1</name>
+      <traffic-profile>3</traffic-profile>
+      <forwarding-operation-type>impose-and-forward
+      </forwarding-operation-type>
+      <incoming-type>
+        <service-sub-layer>
+          <service-sub-layer>ssl-1</service-sub-layer>
+          <service-sub-layer>ssl-2</service-sub-layer>
+        </service-sub-layer>
+      </incoming-type>
+      <outgoing-type>
+        <interface>
+          <outgoing-interface>eth2</outgoing-interface>
+          <mpls-label-stack>
+            <entry>
+              <id>0</id>
+              <label>10000</label>
+            </entry>
+          </mpls-label-stack>
+         </interface>
+      </outgoing-type>
+    </forwarding-sub-layer-list>
+    </forwarding-sub-layer>
+</detnet>
+]]></artwork>
+        </figure>
+      </section>
+      <section numbered="true" toc="default">
+        <name>Example B-2 JSON Service Aggregation Configuration</name>
+        <t>
+                This illustrates the service sub-layers of DetNet. Flows 1
+                and 2 are aggregated into a service sub-layer of aggregated DetNet flow 1. 
+                A diagram illustrating this case is shown and then the 
+                corresponding JSON operational data follows.
+        </t>
+        <figure anchor="case-b2">
+                <name>Case B-2 Example JSON Service Aggregation</name>
+          <artset>
+            <artwork align="left" type="ascii-art" name="" alt=""><![CDATA[
+        
+Please consult the PDF or HTML versions for the Case B-2 Diagram.
+
+]]></artwork>
+        <artwork type="svg">
+<svg
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="210mm"
+   height="120mm"
+   viewBox="0 15 210 110"
+   version="1.1"
+   >
+  <g
+     >
+    <text
+       font-size="2.74992px"
+       
+       x="12.808352"
+       y="63.011162"
+       
+       transform="scale(0.92084851,1.0859549)">Source 1<tspan
+   font-size="2.74992px"
+   x="13.818254"
+   y="65.761101"
+   
+   >192.0.2.1</tspan></text>
+    <path
+       d="m 19.950839,59.601766 c 0,-0.36047 -0.247805,-0.652685 -0.553442,-0.652685 h -6.159573 c -0.305681,0 -0.553477,0.292215 -0.553477,0.652685 v 5.705954 c 0,0.360461 0.247796,0.652676 0.553477,0.652676 h 6.159573 c 0.305637,0 0.553442,-0.292215 0.553442,-0.652676 z"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 18.772551,59.338598 v 0.755983 h -1.494036 l -0.795747,1.69636 -0.811974,-1.69636 h -1.477811 v -0.755983 l -0.958111,0.958807 0.958111,0.958807 v -0.645349 h 1.055571 l 0.909434,1.862304 -0.909434,1.880741 h -1.055571 v -0.700659 l -0.958111,0.958808 0.958111,0.958807 v -0.719111 h 1.477811 l 0.811974,-1.733232 0.795747,1.733232 h 1.494036 v 0.682237 l 0.958121,-0.921933 -0.958121,-0.958808 v 0.700659 h -1.039345 l -0.92566,-1.880741 0.909434,-1.862304 h 1.055571 v 0.626912 l 0.958121,-0.94037 z"
+       stroke="#000000"
+       stroke-width="0.209234"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="43.424561"
+       y="67.076286"
+       
+       transform="scale(0.92084851,1.0859549)">Ingress 1<tspan
+   font-size="2.74992px"
+   x="44.557201"
+   y="69.82621"
+   
+   >192.0.2.2</tspan></text>
+    <path
+       d="m 48.246165,59.601766 c 0,-0.360466 -0.2478,-0.652685 -0.55344,-0.652685 h -6.049511 c -0.30564,0 -0.553439,0.292219 -0.553439,0.652685 v 5.705938 c 0,0.360477 0.247799,0.652692 0.553439,0.652692 h 6.049511 c 0.30564,0 0.55344,-0.292215 0.55344,-0.652692 z"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 47.067838,59.338598 v 0.755983 H 45.5738 l -0.795746,1.69636 -0.811975,-1.69636 H 42.48827 v -0.755983 l -0.958116,0.958807 0.958116,0.958807 v -0.645349 h 1.055573 l 0.90943,1.862304 -0.90943,1.880741 H 42.48827 v -0.700659 l -0.958116,0.958808 0.958116,0.958807 v -0.719111 h 1.477809 l 0.811975,-1.733232 0.795746,1.733232 h 1.494038 v 0.682237 l 0.958116,-0.921933 -0.958116,-0.958808 v 0.700659 h -1.039343 l -0.925659,-1.880741 0.90943,-1.862304 h 1.055572 v 0.626912 l 0.958116,-0.94037 z"
+       stroke="#000000"
+       stroke-width="0.209234"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="75.121887"
+       y="67.076286"
+       
+       transform="scale(0.92084851,1.0859549)">Relay 1<tspan
+   font-size="2.74992px"
+   x="75.296257"
+   y="69.82621"
+   
+   >192.0.2.3</tspan></text>
+    <path
+       d="m 76.541451,59.601761 c 0,-0.360465 -0.2478,-0.65268 -0.55344,-0.65268 H 69.9385 c -0.305682,0 -0.55344,0.292215 -0.55344,0.65268 v 5.705959 c 0,0.360461 0.247758,0.652676 0.55344,0.652676 h 6.049511 c 0.30564,0 0.55344,-0.292215 0.55344,-0.652676 z"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 75.379351,59.338598 v 0.755983 h -1.468737 l -0.782221,1.69636 -0.798202,-1.69636 h -1.452759 v -0.755983 l -0.941928,0.958807 0.941928,0.958807 v -0.645349 h 1.03768 l 0.893992,1.862304 -0.893992,1.880741 h -1.03768 v -0.700659 l -0.941928,0.958808 0.941928,0.958807 v -0.719111 h 1.452759 l 0.798202,-1.733232 0.782221,1.733232 h 1.468737 v 0.682237 l 0.941888,-0.921933 -0.941888,-0.958808 v 0.700659 h -1.021698 l -0.909972,-1.880741 0.893992,-1.862304 h 1.037678 v 0.626912 l 0.941888,-0.94037 z"
+       stroke="#000000"
+       stroke-width="0.209234"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="136.59819"
+       y="67.076286"
+       
+       transform="scale(0.92084851,1.0859549)">Relay 2<tspan
+   font-size="2.74992px"
+   x="136.77255"
+   y="69.82621"
+   
+   >192.0.2.6</tspan></text>
+    <path
+       d="m 133.13201,59.601766 c 0,-0.360466 -0.24779,-0.652685 -0.55343,-0.652685 h -6.04952 c -0.30563,0 -0.55344,0.292219 -0.55344,0.652685 v 5.705938 c 0,0.360477 0.24781,0.652692 0.55344,0.652692 h 6.04952 c 0.30564,0 0.55343,-0.292215 0.55343,-0.652692 z"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 131.96992,59.468435 v 0.740236 h -1.46873 l -0.78222,1.661017 -0.79821,-1.661017 h -1.45275 v -0.740236 l -0.94194,0.938834 0.94194,0.93883 v -0.631903 h 1.03766 l 0.894,1.823502 -0.894,1.841556 h -1.03766 v -0.686069 l -0.94194,0.938839 0.94194,0.93884 v -0.704133 h 1.45275 l 0.79821,-1.69712 0.78222,1.69712 h 1.46873 v 0.668009 l 0.94189,-0.902716 -0.94189,-0.938839 v 0.686069 h -1.02169 l -0.90998,-1.841556 0.894,-1.823502 h 1.03767 v 0.613854 l 0.94189,-0.920781 z"
+       stroke="#000000"
+       stroke-width="0.209234"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="166.77922"
+       y="67.076286"
+       
+       transform="scale(0.92084851,1.0859549)">Egress 1<tspan
+   font-size="2.74992px"
+   x="167.51018"
+   y="69.82621"
+   
+   >192.0.2.77</tspan></text>
+    <path
+       d="m 161.42731,59.601761 c 0,-0.360465 -0.24781,-0.65268 -0.55345,-0.65268 h -6.04951 c -0.30568,0 -0.55344,0.292215 -0.55344,0.65268 v 5.705959 c 0,0.360461 0.24776,0.652676 0.55344,0.652676 h 6.04951 c 0.30564,0 0.55345,-0.292215 0.55345,-0.652676 z"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 160.26525,59.338598 v 0.755983 h -1.46874 l -0.78222,1.69636 -0.7982,-1.69636 h -1.45276 v -0.755983 l -0.94193,0.958807 0.94193,0.958807 v -0.645349 h 1.03767 l 0.89399,1.862304 -0.89399,1.880741 h -1.03767 v -0.700659 l -0.94193,0.958808 0.94193,0.958807 v -0.719111 h 1.45276 l 0.7982,-1.733232 0.78222,1.733232 h 1.46874 v 0.682237 l 0.94188,-0.921933 -0.94188,-0.958808 v 0.700659 h -1.0217 l -0.90998,-1.880741 0.89401,-1.862304 h 1.03767 v 0.626912 l 0.94188,-0.94037 z"
+       stroke="#000000"
+       stroke-width="0.209234"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="105.0231"
+       y="78.67379"
+       
+       transform="scale(0.92084851,1.0859549)">Transit 2<tspan
+   font-size="2.74992px"
+   x="106.03299"
+   y="81.423714"
+   
+   >192.0.2.5</tspan></text>
+    <path
+       d="m 104.83673,76.480813 c 0,-0.360465 -0.24779,-0.65268 -0.55344,-0.65268 h -6.049504 c -0.305682,0 -0.55344,0.292215 -0.55344,0.65268 v 5.705959 c 0,0.36046 0.247758,0.652675 0.55344,0.652675 h 6.049504 c 0.30565,0 0.55344,-0.292215 0.55344,-0.652675 z"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 103.45447,76.347487 v 0.740236 h -1.46873 l -0.78223,1.661018 -0.7982,-1.661018 h -1.452753 v -0.740236 l -0.941936,0.938834 0.941936,0.93883 v -0.631903 h 1.037677 l 0.893976,1.823502 -0.893976,1.841556 h -1.037677 v -0.686069 l -0.941936,0.938839 0.941936,0.93884 v -0.704133 h 1.452753 l 0.7982,-1.69712 0.78223,1.69712 h 1.46873 v 0.66801 l 0.94189,-0.902717 -0.94189,-0.938839 v 0.686069 h -1.02169 l -0.90998,-1.841556 0.894,-1.823502 h 1.03767 v 0.613854 l 0.94189,-0.920781 z"
+       stroke="#000000"
+       stroke-width="0.209234"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="105.0231"
+       y="47.348579"
+       
+       transform="scale(0.92084851,1.0859549)">Transit 1<tspan
+   font-size="2.74992px"
+   x="106.03299"
+   y="50.098503"
+   
+   >192.0.2.4</tspan></text>
+    <path
+       d="m 104.83673,42.592865 c 0,-0.360466 -0.24779,-0.652681 -0.55344,-0.652681 h -6.049504 c -0.305682,0 -0.55344,0.292215 -0.55344,0.652681 v 5.705958 c 0,0.360461 0.247758,0.652675 0.55344,0.652675 h 6.049504 c 0.30565,0 0.55344,-0.292214 0.55344,-0.652675 z"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 103.45447,42.459539 v 0.740236 h -1.46873 l -0.78223,1.661017 -0.7982,-1.661017 h -1.452753 v -0.740236 l -0.941936,0.938838 0.941936,0.938841 v -0.631913 h 1.037677 l 0.893976,1.823506 -0.893976,1.841571 h -1.037677 v -0.686068 l -0.941936,0.938824 0.941936,0.93884 V 47.85785 h 1.452753 l 0.7982,-1.697126 0.78223,1.697126 h 1.46873 v 0.668019 l 0.94189,-0.902731 -0.94189,-0.938824 v 0.686068 h -1.02169 l -0.90998,-1.841571 0.894,-1.823506 h 1.03767 v 0.613848 l 0.94189,-0.920776 z"
+       stroke="#000000"
+       stroke-width="0.209234"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="194.6049"
+       y="63.011162"
+       
+       transform="scale(0.92084851,1.0859549)">Destination 1<tspan
+   font-size="2.74992px"
+   x="198.24837"
+   y="65.761101"
+   
+   >192.0.2.88</tspan></text>
+    <path
+       d="m 189.72259,59.601761 c 0,-0.360465 -0.2478,-0.65268 -0.55344,-0.65268 h -6.04951 c -0.30568,0 -0.55344,0.292215 -0.55344,0.65268 v 5.705959 c 0,0.360461 0.24776,0.652676 0.55344,0.652676 h 6.04951 c 0.30564,0 0.55344,-0.292215 0.55344,-0.652676 z"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 188.56053,59.338598 v 0.755983 h -1.46873 l -0.78222,1.69636 -0.79821,-1.69636 h -1.45275 v -0.755983 l -0.94194,0.958807 0.94194,0.958807 v -0.645349 h 1.03767 l 0.89399,1.862304 -0.89399,1.880741 h -1.03767 v -0.700659 l -0.94194,0.958808 0.94194,0.958807 v -0.719111 h 1.45275 l 0.79821,-1.733232 0.78222,1.733232 h 1.46873 v 0.682237 l 0.94189,-0.921933 -0.94189,-0.958808 v 0.700659 h -1.02169 l -0.90997,-1.880741 0.89399,-1.862304 h 1.03767 v 0.626912 l 0.94189,-0.94037 z"
+       stroke="#000000"
+       stroke-width="0.209234"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 19.950839,62.454731 H 41.073255"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 48.246165,62.454731 H 69.368541"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 76.541451,62.409024 97.663825,45.445834"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 104.83673,45.445834 21.12238,16.96319"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 133.13201,62.454731 h 21.12238"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 161.42731,62.454731 h 21.12237"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 104.83673,79.386369 125.95911,62.454731"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 76.541451,62.454731 97.663825,79.386497"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="12.698243"
+       y="35.511951"
+       
+       transform="scale(0.92084851,1.0859549)">Source 2<tspan
+   font-size="2.74992px"
+   x="13.708145"
+   y="38.261875"
+   
+   >192.0.2.12</tspan></text>
+    <path
+       d="m 19.840773,29.738816 c 0,-0.360465 -0.247796,-0.65268 -0.553442,-0.65268 h -6.049507 c -0.305637,0 -0.553442,0.292215 -0.553442,0.65268 v 5.705935 c 0,0.36047 0.247805,0.65267 0.553442,0.65267 h 6.049507 c 0.305646,0 0.553442,-0.2922 0.553442,-0.65267 z"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 18.662449,29.475653 v 0.755983 h -1.494044 l -0.79574,1.696359 -0.811974,-1.696359 h -1.477809 v -0.755983 l -0.95812,0.958807 0.95812,0.958807 v -0.645348 h 1.055571 l 0.909425,1.862304 -0.909425,1.880741 h -1.055571 v -0.700659 l -0.95812,0.958807 0.95812,0.958806 v -0.71911 h 1.477809 l 0.811974,-1.733232 0.79574,1.733232 h 1.494044 v 0.682238 l 0.958112,-0.921934 -0.958112,-0.958807 v 0.700659 h -1.039345 l -0.92566,-1.880741 0.909435,-1.862304 h 1.05557 v 0.626911 l 0.958112,-0.94037 z"
+       stroke="#000000"
+       stroke-width="0.209234"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 19.840773,32.591785 41.064558,62.461743"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="22.373001"
+       y="14.803868"
+       width="16.734961"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="28.284122"
+       y="18.175455"
+       
+       transform="scale(0.92084851,1.0859549)">DATA 2</text>
+    <rect
+       x="22.373001"
+       y="22.204676"
+       width="16.734961"
+       height="7.660481"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="28.597944"
+       y="23.914433"
+       
+       transform="scale(0.92084851,1.0859549)">IP <tspan
+   font-size="1.91299px"
+   x="32.154896"
+   y="23.914433"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.91299px"
+   x="32.120037"
+   y="26.425243"
+   
+   >192.0.2.89</tspan><tspan
+   font-size="2.74992px"
+   x="194.6049"
+   y="35.511951"
+   
+   >Destination 2</tspan><tspan
+   font-size="2.74992px"
+   x="198.24913"
+   y="38.261875"
+   
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 189.72259,29.608979 c 0,-0.360465 -0.2478,-0.652681 -0.55344,-0.652681 h -6.04951 c -0.30568,0 -0.55344,0.292216 -0.55344,0.652681 v 5.705959 c 0,0.36046 0.24776,0.652675 0.55344,0.652675 h 6.04951 c 0.30564,0 0.55344,-0.292215 0.55344,-0.652675 z"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 188.56053,29.475653 v 0.740236 h -1.46873 l -0.78222,1.661017 -0.79821,-1.661017 h -1.45275 v -0.740236 l -0.94194,0.938834 0.94194,0.938829 v -0.631902 h 1.03767 l 0.89399,1.823503 -0.89399,1.841555 h -1.03767 v -0.686069 l -0.94194,0.938839 0.94194,0.938839 v -0.704132 h 1.45275 l 0.79821,-1.69712 0.78222,1.69712 h 1.46873 v 0.66801 l 0.94189,-0.902717 -0.94189,-0.938839 v 0.686069 h -1.02169 l -0.90997,-1.841555 0.89399,-1.823503 h 1.03767 v 0.613854 l 0.94189,-0.920781 z"
+       stroke="#000000"
+       stroke-width="0.209234"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 161.42731,62.389552 182.54968,32.461948"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="163.62929"
+       y="14.803868"
+       width="16.845058"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="181.72925"
+       y="18.175455"
+       
+       transform="scale(0.92084851,1.0859549)">DATA 2</text>
+    <rect
+       x="163.62929"
+       y="22.204676"
+       width="16.845058"
+       height="7.660481"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="182.04367"
+       y="23.914433"
+       
+       transform="scale(0.92084851,1.0859549)">IP <tspan
+   font-size="1.91299px"
+   x="185.60065"
+   y="23.914433"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.91299px"
+   x="185.56577"
+   y="26.425243"
+   
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 38.272975,60.894976 c -0.121756,-0.173595 0.256788,-0.779814 0.845348,-1.35409 0.588602,-0.574409 1.164429,-0.899267 1.286185,-0.725798 0.121756,0.173594 -0.256662,0.779813 -0.845348,1.354216 -0.588602,0.574277 -1.164387,0.899136 -1.286185,0.725672 L 20.681464,35.8214 c -0.121758,-0.173596 0.256741,-0.779814 0.845349,-1.354223 0.588599,-0.574275 1.164381,-0.899261 1.286184,-0.725666 l 17.591511,25.073704"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       transform="matrix(0.58702042,0.8366944,-0.70948495,0.6922722,0,0)"
+       
+       x="50.871559"
+       y="-0.15083835"
+       >App-2</text>
+    <path
+       d="m 182.32618,35.934361 c -0.12221,0.172816 -0.69692,-0.155807 -1.28264,-0.733724 -0.58569,-0.578041 -0.96116,-1.186726 -0.83894,-1.359409 0.12221,-0.172816 0.69691,0.155674 1.28264,0.733719 0.58574,0.578039 0.96228,1.186594 0.83894,1.359414 l -17.70383,24.962563 c -0.12329,0.172815 -0.69691,-0.155679 -1.28372,-0.733719 -0.58574,-0.578045 -0.96116,-1.186732 -0.83895,-1.359415 L 180.2046,33.841228"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       transform="matrix(0.59079801,-0.8329884,0.7063424,0.6967271,0,0)"
+       
+       x="83.557167"
+       y="169.03973"
+       >App-2</text>
+    <path
+       d="m 50.296721,62.195051 c -0.387658,0 -0.70187,-1.54041 -0.70187,-3.440731 0,-1.900321 0.314212,-3.44073 0.70187,-3.44073 0.387657,0 0.701869,1.540409 0.701869,3.44073 0,1.900321 -0.314212,3.440731 -0.701869,3.440731 h -4.211259 c -0.387658,0 -0.70187,-1.54041 -0.70187,-3.440731 0,-1.900321 0.314212,-3.44073 0.70187,-3.44073 h 4.211259"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="49.71088"
+       y="54.163601"
+       
+       transform="scale(0.92084851,1.0859549)">DN<tspan
+   font-size="2.74992px"
+   x="53.232979"
+   y="54.163601"
+   
+   >-2</tspan></text>
+    <path
+       d="m 50.186615,69.725704 c -0.387657,0 -0.70187,-1.569491 -0.70187,-3.50565 0,-1.936153 0.314213,-3.505649 0.70187,-3.505649 0.387658,0 0.701912,1.569496 0.701912,3.505649 0,1.936159 -0.314254,3.50565 -0.701912,3.50565 h -4.211259 c -0.387656,0 -0.701869,-1.569491 -0.701869,-3.50565 0,-1.936153 0.314213,-3.505649 0.701869,-3.505649 h 4.211259"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="49.611095"
+       y="63.369862"
+       
+       transform="scale(0.92084851,1.0859549)">DN<tspan
+   font-size="2.74992px"
+   x="53.133137"
+   y="63.369862"
+   
+   >-1</tspan></text>
+    <path
+       d="m 148.66911,69.595867 c -0.84336,0 -1.52707,-3.226238 -1.52707,-7.206055 0,-3.979822 0.68371,-7.20606 1.52707,-7.20606 0.84447,0 1.52816,3.226238 1.52816,7.20606 0,3.979817 -0.68369,7.206055 -1.52816,7.206055 H 52.416145 c -0.843684,0 -1.527618,-3.226238 -1.527618,-7.206055 0,-3.979822 0.683934,-7.20606 1.527618,-7.20606 h 96.252965"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="101.30545"
+       y="58.587391"
+       
+       transform="scale(0.92084851,1.0859549)">Aggregated DN-1</text>
+    <path
+       d="m 155.33115,62.065214 c -0.38861,0 -0.70241,-1.569496 -0.70241,-3.50565 0,-1.936159 0.3138,-3.505651 0.70241,-3.505651 0.38757,0 0.70133,1.569492 0.70133,3.505651 0,1.936154 -0.31376,3.50565 -0.70133,3.50565 h -4.21127 c -0.3886,0 -0.7024,-1.569496 -0.7024,-3.50565 0,-1.936159 0.3138,-3.505651 0.7024,-3.505651 h 4.21127"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="163.81647"
+       y="54.044033"
+       
+       transform="scale(0.92084851,1.0859549)">DN<tspan
+   font-size="2.74992px"
+   x="167.33856"
+   y="54.044033"
+   
+   >-2</tspan></text>
+    <path
+       d="m 155.21996,69.46603 c -0.38754,0 -0.70133,-1.540411 -0.70133,-3.440731 0,-1.900321 0.31379,-3.440731 0.70133,-3.440731 0.38866,0 0.70244,1.54041 0.70244,3.440731 0,1.90032 -0.31378,3.440731 -0.70244,3.440731 h -4.21014 c -0.38865,0 -0.70245,-1.540411 -0.70245,-3.440731 0,-1.900321 0.3138,-3.440731 0.70245,-3.440731 h 4.21014"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="163.67421"
+       y="63.250294"
+       
+       transform="scale(0.92084851,1.0859549)">DN<tspan
+   font-size="2.74992px"
+   x="167.19637"
+   y="63.250294"
+   
+   >-1</tspan></text>
+    <path
+       d="M 19.950839,62.454731 H 41.073255"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 161.42731,62.454731 h 21.12237"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="58.925674"
+       y="29.735331"
+       width="8.3674803"
+       height="7.6605062"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.43475px"
+       
+       x="66.678513"
+       y="29.414297"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.43475px"
+   x="66.260056"
+   y="31.088161"
+   
+   >S</tspan><tspan
+   font-size="1.43475px"
+   x="67.062111"
+   y="31.088161"
+   
+   >-</tspan><tspan
+   font-size="1.43475px"
+   x="67.654938"
+   y="31.088161"
+   
+   >label</tspan><tspan
+   font-size="1.91299px"
+   x="66.869598"
+   y="33.359844"
+   
+   >105</tspan></text>
+    <rect
+       x="50.558216"
+       y="44.796646"
+       width="16.734961"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91299px"
+       
+       x="57.9468"
+       y="44.359524"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.91299px"
+   x="63.840206"
+   y="44.359524"
+   
+   >F</tspan><tspan
+   font-size="1.91299px"
+   x="64.851494"
+   y="44.359524"
+   
+   >-</tspan><tspan
+   font-size="1.91299px"
+   x="65.653549"
+   y="44.359524"
+   
+   >label</tspan><tspan
+   font-size="1.91299px"
+   x="61.208088"
+   y="46.750759"
+   
+   >20000</tspan></text>
+    <rect
+       x="50.558216"
+       y="29.735331"
+       width="8.3675013"
+       height="7.6605062"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.43475px"
+       
+       x="57.584278"
+       y="29.414297"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.43475px"
+   x="57.165817"
+   y="31.088161"
+   
+   >S</tspan><tspan
+   font-size="1.43475px"
+   x="57.967873"
+   y="31.088161"
+   
+   >-</tspan><tspan
+   font-size="1.43475px"
+   x="58.560696"
+   y="31.088161"
+   
+   >label</tspan><tspan
+   font-size="1.91299px"
+   x="57.775356"
+   y="33.359844"
+   
+   >102</tspan></text>
+    <rect
+       x="50.558216"
+       y="22.204676"
+       width="8.3675013"
+       height="7.660481"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.55431px"
+       
+       x="58.735786"
+       y="22.718824"
+       
+       transform="scale(0.92084851,1.0859549)">IP<tspan
+   font-size="1.55431px"
+   x="57.008881"
+   y="24.512253"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.55431px"
+   x="57.008881"
+   y="26.305681"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="58.925674"
+       y="22.204676"
+       width="8.3674803"
+       height="7.660481"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.55431px"
+       
+       x="67.830025"
+       y="22.718824"
+       
+       transform="scale(0.92084851,1.0859549)">IP<tspan
+   font-size="1.55431px"
+   x="66.103119"
+   y="24.512253"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.55431px"
+   x="66.103119"
+   y="26.305681"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="50.558216"
+       y="14.803868"
+       width="8.3675013"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.67387px"
+       
+       x="57.148384"
+       y="16.740717"
+       
+       transform="scale(0.92084851,1.0859549)">DATA <tspan
+   font-size="1.67387px"
+   x="58.961731"
+   y="18.773273"
+   
+   >1</tspan></text>
+    <rect
+       x="58.925674"
+       y="14.803868"
+       width="8.3674803"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.67387px"
+       
+       x="66.242622"
+       y="16.740717"
+       
+       transform="scale(0.92084851,1.0859549)">DATA <tspan
+   font-size="1.67387px"
+   x="68.055969"
+   y="18.773273"
+   
+   >2</tspan></text>
+    <rect
+       x="5.6380901"
+       y="50.509552"
+       width="16.734961"
+       height="7.530642"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="10.462574"
+       y="49.859375"
+       
+       transform="scale(0.92084851,1.0859549)">IP <tspan
+   font-size="1.91299px"
+   x="14.019544"
+   y="49.859375"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.91299px"
+   x="13.984626"
+   y="52.370171"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="50.558216"
+       y="37.26598"
+       width="16.734961"
+       height="7.6605062"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91299px"
+       
+       x="57.77232"
+       y="37.424942"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.91299px"
+   x="63.665733"
+   y="37.424942"
+   
+   >A-label</tspan><tspan
+   font-size="1.91299px"
+   x="61.765884"
+   y="39.816174"
+   
+   >1000</tspan></text>
+    <rect
+       x="78.633316"
+       y="44.796646"
+       width="16.734961"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91299px"
+       
+       x="88.430183"
+       y="44.359524"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.91299px"
+   x="94.323647"
+   y="44.359524"
+   
+   >F</tspan><tspan
+   font-size="1.91299px"
+   x="95.334923"
+   y="44.359524"
+   
+   >-</tspan><tspan
+   font-size="1.91299px"
+   x="96.136978"
+   y="44.359524"
+   
+   >label</tspan><tspan
+   font-size="1.91299px"
+   x="91.691467"
+   y="46.750759"
+   
+   >20001</tspan></text>
+    <rect
+       x="78.853516"
+       y="109.19672"
+       width="16.734961"
+       height="7.6605062"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91299px"
+       
+       x="88.656288"
+       y="103.66222"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.91299px"
+   x="94.549698"
+   y="103.66222"
+   
+   >F</tspan><tspan
+   font-size="1.91299px"
+   x="95.560974"
+   y="103.66222"
+   
+   >-</tspan><tspan
+   font-size="1.91299px"
+   x="96.363037"
+   y="103.66222"
+   
+   >label</tspan><tspan
+   font-size="1.91299px"
+   x="91.917526"
+   y="106.05347"
+   
+   >20002</tspan></text>
+    <rect
+       x="78.633316"
+       y="37.26598"
+       width="16.734961"
+       height="7.6605062"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91299px"
+       
+       x="88.255699"
+       y="37.424942"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.91299px"
+   x="94.149109"
+   y="37.424942"
+   
+   >A-label</tspan><tspan
+   font-size="1.91299px"
+   x="92.249329"
+   y="39.816174"
+   
+   >1001</tspan></text>
+    <rect
+       x="78.853516"
+       y="101.79588"
+       width="16.734961"
+       height="7.530654"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91299px"
+       
+       x="88.481865"
+       y="96.727638"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.91299px"
+   x="94.375275"
+   y="96.727638"
+   
+   >A-label</tspan><tspan
+   font-size="1.91299px"
+   x="92.475433"
+   y="99.118874"
+   
+   >1001</tspan></text>
+    <rect
+       x="78.633316"
+       y="29.735331"
+       width="8.3674803"
+       height="7.6605062"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.43475px"
+       
+       x="88.067657"
+       y="29.414297"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.43475px"
+   x="87.6492"
+   y="31.088161"
+   
+   >S-label</tspan><tspan
+   font-size="1.91299px"
+   x="88.258743"
+   y="33.359844"
+   
+   >102</tspan></text>
+    <rect
+       x="78.633316"
+       y="22.204676"
+       width="8.3674803"
+       height="7.660481"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.55431px"
+       
+       x="89.21917"
+       y="22.718824"
+       
+       transform="scale(0.92084851,1.0859549)">IP<tspan
+   font-size="1.55431px"
+   x="87.492264"
+   y="24.512253"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.55431px"
+   x="87.492264"
+   y="26.305681"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="78.633316"
+       y="14.803868"
+       width="8.3674803"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.67387px"
+       
+       x="87.631767"
+       y="16.740717"
+       
+       transform="scale(0.92084851,1.0859549)">DATA<tspan
+   font-size="1.67387px"
+   x="89.445107"
+   y="18.773273"
+   
+   >1</tspan></text>
+    <rect
+       x="87.000771"
+       y="29.735331"
+       width="8.3674803"
+       height="7.6605062"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.43475px"
+       
+       x="97.161896"
+       y="29.414297"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.43475px"
+   x="96.743439"
+   y="31.088161"
+   
+   >S</tspan><tspan
+   font-size="1.43475px"
+   x="97.545494"
+   y="31.088161"
+   
+   >-</tspan><tspan
+   font-size="1.43475px"
+   x="98.138313"
+   y="31.088161"
+   
+   >label</tspan><tspan
+   font-size="1.91299px"
+   x="97.352982"
+   y="33.359844"
+   
+   >105</tspan></text>
+    <rect
+       x="87.000771"
+       y="22.204676"
+       width="8.3674803"
+       height="7.660481"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.55431px"
+       
+       x="98.3134"
+       y="22.718824"
+       
+       transform="scale(0.92084851,1.0859549)">IP<tspan
+   font-size="1.55431px"
+   x="96.586502"
+   y="24.512253"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.55431px"
+   x="96.586502"
+   y="26.305681"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="87.000771"
+       y="14.803868"
+       width="8.3674803"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.67387px"
+       
+       x="96.725998"
+       y="16.740717"
+       
+       transform="scale(0.92084851,1.0859549)">DATA <tspan
+   font-size="1.67387px"
+   x="98.539352"
+   y="18.773273"
+   
+   >2</tspan></text>
+    <rect
+       x="78.853516"
+       y="94.395096"
+       width="8.3674803"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.43475px"
+       
+       x="88.293762"
+       y="88.836555"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.43475px"
+   x="87.875305"
+   y="90.510422"
+   
+   >S</tspan><tspan
+   font-size="1.43475px"
+   x="88.677361"
+   y="90.510422"
+   
+   >-</tspan><tspan
+   font-size="1.43475px"
+   x="89.270187"
+   y="90.510422"
+   
+   >label</tspan><tspan
+   font-size="1.91299px"
+   x="88.484901"
+   y="92.782097"
+   
+   >102</tspan></text>
+    <rect
+       x="87.22097"
+       y="94.395096"
+       width="8.3674803"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.43475px"
+       
+       x="97.42115"
+       y="88.836555"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.43475px"
+   x="97.002693"
+   y="90.510422"
+   
+   >S</tspan><tspan
+   font-size="1.43475px"
+   x="97.804741"
+   y="90.510422"
+   
+   >-</tspan><tspan
+   font-size="1.43475px"
+   x="98.397575"
+   y="90.510422"
+   
+   >label</tspan><tspan
+   font-size="1.91299px"
+   x="97.612244"
+   y="92.782097"
+   
+   >105</tspan></text>
+    <rect
+       x="78.853516"
+       y="86.864433"
+       width="8.3674803"
+       height="7.530642"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.55431px"
+       
+       x="89.445267"
+       y="82.260643"
+       
+       transform="scale(0.92084851,1.0859549)">IP<tspan
+   font-size="1.55431px"
+   x="87.718422"
+   y="84.054077"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.55431px"
+   x="87.718422"
+   y="85.847504"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="87.22097"
+       y="86.864433"
+       width="8.3674803"
+       height="7.530642"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.55431px"
+       
+       x="98.572662"
+       y="82.260643"
+       
+       transform="scale(0.92084851,1.0859549)">IP<tspan
+   font-size="1.55431px"
+   x="96.845764"
+   y="84.054077"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.55431px"
+   x="96.845764"
+   y="85.847504"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="78.853516"
+       y="79.463615"
+       width="8.3674803"
+       height="7.530642"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.67387px"
+       
+       x="87.857826"
+       y="76.282562"
+       
+       transform="scale(0.92084851,1.0859549)">DATA <tspan
+   font-size="1.67387px"
+   x="89.671211"
+   y="78.315102"
+   
+   >1</tspan></text>
+    <rect
+       x="87.22097"
+       y="79.463615"
+       width="8.3674803"
+       height="7.530642"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.67387px"
+       
+       x="96.985214"
+       y="76.282562"
+       
+       transform="scale(0.92084851,1.0859549)">DATA <tspan
+   font-size="1.67387px"
+   x="98.798546"
+   y="78.315102"
+   
+   >2</tspan></text>
+    <rect
+       x="115.51627"
+       y="29.735331"
+       width="8.4775782"
+       height="7.6605062"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.43475px"
+       
+       x="128.18581"
+       y="29.414297"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.43475px"
+   x="127.76733"
+   y="31.088161"
+   
+   >S</tspan><tspan
+   font-size="1.43475px"
+   x="128.5694"
+   y="31.088161"
+   
+   >-</tspan><tspan
+   font-size="1.43475px"
+   x="129.16223"
+   y="31.088161"
+   
+   >label</tspan><tspan
+   font-size="1.91299px"
+   x="128.37694"
+   y="33.359844"
+   
+   >105</tspan></text>
+    <rect
+       x="107.14881"
+       y="44.796646"
+       width="16.845058"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91299px"
+       
+       x="119.45421"
+       y="44.359524"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.91299px"
+   x="125.3476"
+   y="44.359524"
+   
+   >F</tspan><tspan
+   font-size="1.91299px"
+   x="126.35893"
+   y="44.359524"
+   
+   >-</tspan><tspan
+   font-size="1.91299px"
+   x="127.161"
+   y="44.359524"
+   
+   >label</tspan><tspan
+   font-size="1.91299px"
+   x="122.71549"
+   y="46.750759"
+   
+   >20003</tspan></text>
+    <rect
+       x="107.25889"
+       y="109.19672"
+       width="16.734961"
+       height="7.6605062"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91299px"
+       
+       x="119.47336"
+       y="103.66222"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.91299px"
+   x="125.36674"
+   y="103.66222"
+   
+   >F</tspan><tspan
+   font-size="1.91299px"
+   x="126.37802"
+   y="103.66222"
+   
+   >-</tspan><tspan
+   font-size="1.91299px"
+   x="127.18009"
+   y="103.66222"
+   
+   >label</tspan><tspan
+   font-size="1.91299px"
+   x="122.73457"
+   y="106.05347"
+   
+   >20004</tspan></text>
+    <rect
+       x="107.25889"
+       y="101.79588"
+       width="16.734961"
+       height="7.530654"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91299px"
+       
+       x="119.2988"
+       y="96.727638"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.91299px"
+   x="125.19222"
+   y="96.727638"
+   
+   >A-label</tspan><tspan
+   font-size="1.91299px"
+   x="123.29238"
+   y="99.118874"
+   
+   >1001</tspan></text>
+    <rect
+       x="107.14881"
+       y="37.26598"
+       width="16.845058"
+       height="7.6605062"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91299px"
+       
+       x="119.27966"
+       y="37.424942"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.91299px"
+   x="125.17307"
+   y="37.424942"
+   
+   >A-label</tspan><tspan
+   font-size="1.91299px"
+   x="123.27324"
+   y="39.816174"
+   
+   >1001</tspan></text>
+    <rect
+       x="107.14881"
+       y="29.735331"
+       width="8.3674803"
+       height="7.6605062"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.43475px"
+       
+       x="119.0908"
+       y="29.414297"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.43475px"
+   x="118.67229"
+   y="31.088161"
+   
+   >S-label</tspan><tspan
+   font-size="1.91299px"
+   x="119.28188"
+   y="33.359844"
+   
+   >102</tspan></text>
+    <rect
+       x="107.14881"
+       y="22.204676"
+       width="8.3674803"
+       height="7.660481"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.55431px"
+       
+       x="120.24334"
+       y="22.718824"
+       
+       transform="scale(0.92084851,1.0859549)">IP<tspan
+   font-size="1.55431px"
+   x="118.51652"
+   y="24.512253"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.55431px"
+   x="118.51652"
+   y="26.305681"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="115.51627"
+       y="22.204676"
+       width="8.4775782"
+       height="7.660481"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.55431px"
+       
+       x="129.33725"
+       y="22.718824"
+       
+       transform="scale(0.92084851,1.0859549)">IP<tspan
+   font-size="1.55431px"
+   x="127.61037"
+   y="24.512253"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.55431px"
+   x="127.61037"
+   y="26.305681"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="107.14881"
+       y="14.803868"
+       width="8.3674803"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.67387px"
+       
+       x="118.65557"
+       y="16.740717"
+       
+       transform="scale(0.92084851,1.0859549)">DATA <tspan
+   font-size="1.67387px"
+   x="120.46891"
+   y="18.773273"
+   
+   >1</tspan></text>
+    <rect
+       x="115.51627"
+       y="14.803868"
+       width="8.4775782"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.67387px"
+       
+       x="127.74941"
+       y="16.740717"
+       
+       transform="scale(0.92084851,1.0859549)">DATA <tspan
+   font-size="1.67387px"
+   x="129.56276"
+   y="18.773273"
+   
+   >2</tspan></text>
+    <rect
+       x="107.14881"
+       y="94.395096"
+       width="8.3674803"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.43475px"
+       
+       x="119.0908"
+       y="88.836555"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.43475px"
+   x="118.67229"
+   y="90.510422"
+   
+   >S-label</tspan><tspan
+   font-size="1.91299px"
+   x="119.28188"
+   y="92.782097"
+   
+   >102</tspan></text>
+    <rect
+       x="115.6264"
+       y="94.395096"
+       width="8.3674803"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.43475px"
+       
+       x="128.205"
+       y="88.836555"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.43475px"
+   x="127.78648"
+   y="90.510422"
+   
+   >S-label</tspan><tspan
+   font-size="1.91299px"
+   x="128.39609"
+   y="92.782097"
+   
+   >105</tspan></text>
+    <rect
+       x="107.14881"
+       y="86.864433"
+       width="8.3674803"
+       height="7.530642"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.55431px"
+       
+       x="120.24334"
+       y="82.260643"
+       
+       transform="scale(0.92084851,1.0859549)">IP<tspan
+   font-size="1.55431px"
+   x="118.51652"
+   y="84.054077"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.55431px"
+   x="118.51652"
+   y="85.847504"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="115.6264"
+       y="86.864433"
+       width="8.3674803"
+       height="7.530642"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.55431px"
+       
+       x="129.35634"
+       y="82.260643"
+       
+       transform="scale(0.92084851,1.0859549)">IP<tspan
+   font-size="1.55431px"
+   x="127.62944"
+   y="84.054077"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.55431px"
+   x="127.62944"
+   y="85.847504"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="107.14881"
+       y="79.463615"
+       width="8.3674803"
+       height="7.530642"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.67387px"
+       
+       x="118.65557"
+       y="76.282562"
+       
+       transform="scale(0.92084851,1.0859549)">DATA <tspan
+   font-size="1.67387px"
+   x="120.46891"
+   y="78.315102"
+   
+   >1</tspan></text>
+    <rect
+       x="115.6264"
+       y="79.463615"
+       width="8.3674803"
+       height="7.530642"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.67387px"
+       
+       x="127.76977"
+       y="76.282562"
+       
+       transform="scale(0.92084851,1.0859549)">DATA <tspan
+   font-size="1.67387px"
+   x="129.58311"
+   y="78.315102"
+   
+   >2</tspan></text>
+    <rect
+       x="143.92168"
+       y="29.735331"
+       width="8.3674803"
+       height="7.6605062"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.43475px"
+       
+       x="158.93114"
+       y="29.414297"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.43475px"
+   x="158.51268"
+   y="31.088161"
+   
+   >S</tspan><tspan
+   font-size="1.43475px"
+   x="159.31476"
+   y="31.088161"
+   
+   >-</tspan><tspan
+   font-size="1.43475px"
+   x="159.90758"
+   y="31.088161"
+   
+   >label</tspan><tspan
+   font-size="1.91299px"
+   x="159.12227"
+   y="33.359844"
+   
+   >105</tspan></text>
+    <rect
+       x="135.5542"
+       y="44.796646"
+       width="16.734961"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91299px"
+       
+       x="150.19954"
+       y="44.359524"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.91299px"
+   x="156.09296"
+   y="44.359524"
+   
+   >F</tspan><tspan
+   font-size="1.91299px"
+   x="157.10428"
+   y="44.359524"
+   
+   >-</tspan><tspan
+   font-size="1.91299px"
+   x="157.90636"
+   y="44.359524"
+   
+   >label</tspan><tspan
+   font-size="1.91299px"
+   x="153.46083"
+   y="46.750759"
+   
+   >20005</tspan></text>
+    <rect
+       x="135.5542"
+       y="29.735331"
+       width="8.3674803"
+       height="7.6605062"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.43475px"
+       
+       x="149.8373"
+       y="29.414297"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.43475px"
+   x="149.41884"
+   y="31.088161"
+   
+   >S</tspan><tspan
+   font-size="1.43475px"
+   x="150.22089"
+   y="31.088161"
+   
+   >-</tspan><tspan
+   font-size="1.43475px"
+   x="150.81372"
+   y="31.088161"
+   
+   >label</tspan><tspan
+   font-size="1.91299px"
+   x="150.02837"
+   y="33.359844"
+   
+   >102</tspan></text>
+    <rect
+       x="135.5542"
+       y="22.204676"
+       width="8.3674803"
+       height="7.660481"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.55431px"
+       
+       x="150.98869"
+       y="22.718824"
+       
+       transform="scale(0.92084851,1.0859549)">IP<tspan
+   font-size="1.55431px"
+   x="149.26186"
+   y="24.512253"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.55431px"
+   x="149.26186"
+   y="26.305681"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="143.92168"
+       y="22.204676"
+       width="8.3674803"
+       height="7.660481"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.55431px"
+       
+       x="160.08261"
+       y="22.718824"
+       
+       transform="scale(0.92084851,1.0859549)">IP<tspan
+   font-size="1.55431px"
+   x="158.3557"
+   y="24.512253"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.55431px"
+   x="158.3557"
+   y="26.305681"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="135.5542"
+       y="14.803868"
+       width="8.3674803"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.67387px"
+       
+       x="149.40207"
+       y="16.740717"
+       
+       transform="scale(0.92084851,1.0859549)">DATA <tspan
+   font-size="1.67387px"
+   x="151.21541"
+   y="18.773273"
+   
+   >1</tspan></text>
+    <rect
+       x="143.92168"
+       y="14.803868"
+       width="8.3674803"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.67387px"
+       
+       x="158.49599"
+       y="16.740717"
+       
+       transform="scale(0.92084851,1.0859549)">DATA <tspan
+   font-size="1.67387px"
+   x="160.30933"
+   y="18.773273"
+   
+   >2</tspan></text>
+    <rect
+       x="135.5542"
+       y="37.26598"
+       width="16.734961"
+       height="7.6605062"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91299px"
+       
+       x="150.02502"
+       y="37.424942"
+       
+       transform="scale(0.92084851,1.0859549)">MPLS<tspan
+   font-size="1.91299px"
+   x="155.91843"
+   y="37.424942"
+   
+   >A-label</tspan><tspan
+   font-size="1.91299px"
+   x="154.01859"
+   y="39.816174"
+   
+   >1002</tspan></text>
+    <rect
+       x="180.36424"
+       y="50.509552"
+       width="16.624861"
+       height="7.4007897"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="200.07483"
+       y="49.859375"
+       
+       transform="scale(0.92084851,1.0859549)">IP <tspan
+   font-size="1.91299px"
+   x="203.63179"
+   y="49.859375"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.91299px"
+   x="203.59692"
+   y="52.370171"
+   
+   >192.0.2.88</tspan></text>
+    <path
+       d="m 39.644715,64.012797 c -0.190043,0 -0.344048,-0.726579 -0.344048,-1.622985 0,-0.896411 0.154005,-1.62299 0.344048,-1.62299 0.190042,0 0.344047,0.726579 0.344047,1.62299 0,0.896406 -0.154005,1.622985 -0.344047,1.622985 H 20.955519 c -0.190044,0 -0.344087,-0.726579 -0.344087,-1.622985 0,-0.896411 0.154043,-1.62299 0.344087,-1.62299 h 18.689196"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="29.617666"
+       y="61.815563"
+       
+       transform="scale(0.92084851,1.0859549)">App-1</text>
+    <path
+       d="m 181.12173,64.142634 c -0.19047,0 -0.34464,-0.726579 -0.34464,-1.622985 0,-0.896406 0.15417,-1.622985 0.34464,-1.622985 0.18937,0 0.3435,0.726579 0.3435,1.622985 0,0.896406 -0.15413,1.622985 -0.3435,1.622985 h -18.5791 c -0.1905,0 -0.34463,-0.726579 -0.34463,-1.622985 0,-0.896406 0.15413,-1.622985 0.34463,-1.622985 h 18.5791"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="183.38637"
+       y="61.815563"
+       
+       transform="scale(0.92084851,1.0859549)">App-1</text>
+    <rect
+       x="5.6380901"
+       y="42.978901"
+       width="16.734961"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="10.148652"
+       y="44.120396"
+       
+       transform="scale(0.92084851,1.0859549)">DATA 1</text>
+    <rect
+       x="180.36424"
+       y="42.978901"
+       width="16.624861"
+       height="7.5306678"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="199.76157"
+       y="44.120396"
+       
+       transform="scale(0.92084851,1.0859549)">DATA 1</text>
+    <path
+       d="m 71.366832,41.096233 c 0,-1.756851 1.207663,-3.181052 2.697415,-3.181052 1.489709,0 2.697372,1.424201 2.697372,3.181052 0,1.756851 -1.207663,3.181051 -2.697372,3.181051 -1.489752,0 -2.697415,-1.4242 -2.697415,-3.181051 z"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.0216px"
+       
+       x="78.877823"
+       y="39.696613"
+       
+       transform="scale(0.92084851,1.0859549)">R</text>
+    <path
+       d="m 125.64531,41.096233 c 0,-1.756851 1.20779,-3.181052 2.69742,-3.181052 1.48962,0 2.69741,1.424201 2.69741,3.181052 0,1.756851 -1.20779,3.181051 -2.69741,3.181051 -1.48963,0 -2.69742,-1.4242 -2.69742,-3.181051 z"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.0216px"
+       
+       x="138.0688"
+       y="39.696613"
+       
+       transform="scale(0.92084851,1.0859549)">E</text>
+    <path
+       d="m 71.366832,105.56123 c 0,-1.79308 1.207663,-3.24598 2.697415,-3.24598 1.489709,0 2.697372,1.4529 2.697372,3.24598 0,1.79307 -1.207663,3.24596 -2.697372,3.24596 -1.489752,0 -2.697415,-1.45289 -2.697415,-3.24596 z"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.0216px"
+       
+       x="78.877823"
+       y="99.118874"
+       
+       transform="scale(0.92084851,1.0859549)">R</text>
+    <path
+       d="m 125.64531,105.56123 c 0,-1.79308 1.20779,-3.24598 2.69742,-3.24598 1.48962,0 2.69741,1.4529 2.69741,3.24598 0,1.79307 -1.20779,3.24596 -2.69741,3.24596 -1.48963,0 -2.69742,-1.45289 -2.69742,-3.24596 z"
+       stroke="#000000"
+       stroke-width="0.278978"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="4.61682px"
+       
+       x="150.25476"
+       y="91.128922"
+       
+       transform="scale(0.84661926,1.1811685)">E<tspan
+   font-size="3.6275px"
+   x="162.79132"
+   y="82.884621"
+   
+   >Notes:</tspan><tspan
+   font-size="3.6275px"
+   x="162.79132"
+   y="87.171661"
+   
+   >-</tspan><tspan
+   font-size="3.6275px"
+   x="168.56235"
+   y="87.171661"
+   
+   >S and A labels in this diagram include d-CWs</tspan><tspan
+   font-size="3.6275px"
+   x="168.56235"
+   y="91.458702"
+   
+   >of their own.</tspan></text>
+    <path
+       d="m 37.841833,54.27332 c 0,-0.321738 0.221209,-0.582718 0.494144,-0.582718 h 14.315442 c 0.272932,0 0.4941,0.26098 0.4941,0.582718 v 17.920882 c 0,0.321869 -0.221168,0.582717 -0.4941,0.582717 H 38.335977 c -0.272935,0 -0.494144,-0.260848 -0.494144,-0.582717 z"
+       stroke="#000000"
+       stroke-width="0.557954"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.23184, 1.67387"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 148.93114,54.302664 c 0,-0.33797 0.23232,-0.612062 0.51856,-0.612062 h 15.03725 c 0.28625,0 0.51857,0.274092 0.51857,0.612062 v 17.862197 c 0,0.33797 -0.23232,0.612058 -0.51857,0.612058 H 149.4497 c -0.28624,0 -0.51856,-0.274088 -0.51856,-0.612058 z"
+       stroke="#000000"
+       stroke-width="0.557954"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.23184, 1.67387"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.74992px"
+       
+       x="42.024494"
+       y="75.326057"
+       
+       transform="scale(0.92084851,1.0859549)">aggregation<tspan
+   font-size="2.74992px"
+   x="163.04509"
+   y="75.326057"
+   
+   >disaggregation</tspan></text>
+  </g>
+</svg>
+</artwork>
+</artset>
+        </figure>
+        <figure anchor="example-detnet-json-service-aggregation-b-2">
+          <name>Example B-2 DetNet JSON Service Aggregation</name>
+          <artwork name="" type="" align="left" alt=""><![CDATA[
+{
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "eth0",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-10-02T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth1",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-10-02T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth2",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-10-02T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth3",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-10-02T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth4",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-10-02T23:59:00Z"
+        }
+      }
+    ]
+  },
+  "ietf-detnet:detnet": {
+    "app-flows": {
+      "app-flow": [
+        {
+          "name": "app-1",
+          "app-flow-bidir-congruent": false,
+          "outgoing-service": "ssl-1",
+          "traffic-profile": "1",
+          "ingress": {
+            "app-flow-status": "ready",
+            "interface": "eth0",
+            "ip-app-flow": {
+              "src-ip-prefix": "192.0.2.1/32",
+              "dest-ip-prefix": "192.0.2.88/32",
+              "dscp": 6
+            }
+          }
+        },
+        {
+          "name": "app-2",
+          "app-flow-bidir-congruent": false,
+          "outgoing-service": "ssl-2",
+          "traffic-profile": "1",
+          "ingress": {
+            "app-flow-status": "ready",
+            "interface": "eth0",
+            "ip-app-flow": {
+              "src-ip-prefix": "192.0.2.12/32",
+              "dest-ip-prefix": "192.0.2.89/32",
+              "dscp": 7
+            }
+          }
+        }
+      ]
+    },
+    "traffic-profile": [
+      {
+        "profile-name": "1",
+        "traffic-requirements": {
+          "min-bandwidth": "100000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 200000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "member-apps": [
+          "app-1",
+          "app-2"
+        ]
+      },
+      {
+        "profile-name": "2",
+        "traffic-requirements": {
+          "min-bandwidth": "100000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 200000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "member-services": [
+          "ssl-1",
+          "ssl-2"
+        ]
+      },
+      {
+        "profile-name": "3",
+        "flow-spec": {
+          "interval": 5,
+          "max-pkts-per-interval": 10,
+          "max-payload-size": 1500
+        },
+        "member-fwd-sublayers": [
+          "afl-1"
+        ]
+      }
+    ],
+    "service-sub-layer": {
+      "service-sub-layer-list": [
+        {
+          "name": "ssl-1",
+          "service-rank": 10,
+          "traffic-profile": "2",
+          "service-protection": {
+            "service-protection-type": "none",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-initiation",
+          "incoming-type": {
+            "app-flow": {
+              "app-flow-list": [
+                "app-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "aggregation-service-sub-layer": "asl-1",
+              "service-label": {
+                "mpls-label-stack": {
+                  "entry": [
+                    {
+                      "id": 0,
+                      "label": 102
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "ssl-2",
+          "service-rank": 10,
+          "traffic-profile": "2",
+          "service-operation-type": "service-initiation",
+          "service-protection": {
+            "service-protection-type": "none",
+            "sequence-number-length": "long-sn"
+          },
+          "incoming-type": {
+            "app-flow": {
+              "app-flow-list": [
+                "app-2"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "aggregation-service-sub-layer": "asl-1",
+              "service-label": {
+                "mpls-label-stack": {
+                  "entry": [
+                    {
+                      "id": 0,
+                      "label": 105
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "asl-1",
+          "service-rank": 10,
+          "service-protection": {
+            "service-protection-type": "none",
+            "sequence-number-length": "long-sn"
+          },
+          "incoming-type": {
+            "service-aggregation": {
+              "service-sub-layer": [
+                "ssl-1",
+                "ssl-2"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 1000
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "afl-1"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "forwarding-sub-layer": {
+      "forwarding-sub-layer-list": [
+        {
+          "name": "afl-1",
+          "traffic-profile": "3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "asl-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth2",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20000
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+]]></artwork>
+        </figure>
+      </section>
+      <section numbered="true" toc="default">
+              <name>Example C-1 JSON Relay Aggregation/Disaggregation Configuration</name>
+        <t>
+                This illustrates the Relay node 1 aggregating the forwarding 
+                sub-layers of DetNet flows 1 and 2 into a forwarding sub-layer. 
+                A diagram illustrating both aggregation and disaggregation is shown and then the 
+                corresponding JSON operational data follows.
+        </t>
+        <figure anchor="case-c1">
+                <name>Case C-1 Example JSON Service Aggregation/Disaggregation</name>
+          <artset>
+            <artwork align="left" type="ascii-art" name="" alt=""><![CDATA[
+        
+Please consult the PDF or HTML versions for the Case C-1 Diagram.
+
+]]></artwork>
+        <artwork type="svg">
+<svg
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="210mm"
+   height="120mm"
+   viewBox="0 15 210 110"
+   version="1.1"
+   >
+  <g
+     >
+    <path
+       d="m 75.42501,61.215386 c 0,-0.3576 -0.272888,-0.64749 -0.609509,-0.64749 h -6.518949 c -0.336625,0 -0.609513,0.28989 -0.609513,0.64749 v 5.66046 c 0,0.35759 0.272888,0.64749 0.609513,0.64749 h 6.518949 c 0.336621,0 0.609509,-0.2899 0.609509,-0.64749 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 74.168483,61.073746 v 0.72099 h -1.588066 l -0.845818,1.61782 -0.86308,-1.61782 h -1.570806 v -0.72099 l -1.018446,0.91442 1.018446,0.91442 v -0.61547 h 1.122004 l 0.96665,1.77608 -0.96665,1.79366 h -1.122004 v -0.66822 l -1.018446,0.91442 1.018446,0.91442 v -0.68581 h 1.570806 l 0.86308,-1.65299 0.845818,1.65299 h 1.588066 v 0.65063 l 1.018436,-0.87924 -1.018436,-0.91442 v 0.66822 h -1.104741 l -0.983911,-1.79366 0.96665,-1.77608 h 1.122002 v 0.59789 l 1.018436,-0.89684 z"
+       stroke="#000000"
+       stroke-width="0.214721"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 136.85249,61.215386 c 0,-0.3576 -0.27288,-0.64749 -0.60951,-0.64749 h -6.51894 c -0.33663,0 -0.60952,0.28989 -0.60952,0.64749 v 5.66046 c 0,0.35759 0.27289,0.64749 0.60952,0.64749 h 6.51894 c 0.33663,0 0.60951,-0.2899 0.60951,-0.64749 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 135.57841,61.073746 v 0.72099 h -1.61545 l -0.86039,1.61782 -0.87796,-1.61782 h -1.59788 v -0.72099 l -1.036,0.91442 1.036,0.91442 v -0.61547 h 1.14134 l 0.98332,1.77608 -0.98332,1.79366 h -1.14134 v -0.66822 l -1.036,0.91442 1.036,0.91442 v -0.68581 h 1.59788 l 0.87796,-1.65299 0.86039,1.65299 h 1.61545 v 0.65063 l 1.03599,-0.87924 -1.03599,-0.91442 v 0.66822 h -1.12379 l -1.00088,-1.79366 0.98332,-1.77608 h 1.14135 v 0.59789 l 1.03599,-0.89684 z"
+       stroke="#000000"
+       stroke-width="0.214721"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="5.7053642"
+       y="67.599197"
+       
+       transform="scale(0.97023256,1.0306807)">Source 1<tspan
+   font-size="2.82205px"
+   x="6.741765"
+   y="70.421249"
+   
+   >192.0.2.1</tspan></text>
+    <path
+       d="m 14.354661,61.077146 c 0,-0.35109 -0.267918,-0.63571 -0.598424,-0.63571 H 7.0961038 c -0.3305065,0 -0.5984336,0.28462 -0.5984336,0.63571 v 5.55757 c 0,0.35109 0.2679271,0.6357 0.5984336,0.6357 h 6.6601332 c 0.330506,0 0.598424,-0.28461 0.598424,-0.6357 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 12.860049,60.820826 v 0.73632 h -1.588066 l -0.845817,1.65225 -0.8630874,-1.65225 H 7.9922829 v -0.73632 l -1.0184488,0.93387 1.0184488,0.93388 v -0.62857 h 1.1219992 l 0.9666469,1.81387 -0.9666469,1.83183 H 7.9922829 v -0.68244 l -1.0184488,0.93388 1.0184488,0.93387 v -0.70041 h 1.5707957 l 0.8630874,-1.68816 0.845817,1.68816 h 1.588066 v 0.6645 l 1.018431,-0.89796 -1.018431,-0.93388 v 0.68244 h -1.104738 l -0.983908,-1.83183 0.966638,-1.81387 h 1.122008 v 0.61061 l 1.018431,-0.91592 z"
+       stroke="#000000"
+       stroke-width="0.214721"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="37.124619"
+       y="67.599197"
+       
+       transform="scale(0.97023256,1.0306807)">Ingress 1<tspan
+   font-size="2.82205px"
+   x="38.286976"
+   y="70.421249"
+   
+   >192.0.2.2</tspan></text>
+    <path
+       d="m 44.94936,61.077146 c 0,-0.35109 -0.267927,-0.63571 -0.59843,-0.63571 h -6.541087 c -0.330506,0 -0.59843,0.28462 -0.59843,0.63571 v 5.55756 c 0,0.3511 0.267924,0.63571 0.59843,0.63571 h 6.541087 c 0.330503,0 0.59843,-0.28461 0.59843,-0.63571 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 43.454742,60.820826 v 0.73632 h -1.588066 l -0.845819,1.65225 -0.863079,-1.65225 h -1.570806 v -0.73632 l -1.018446,0.93387 1.018446,0.93388 v -0.62857 h 1.122004 l 0.96665,1.81387 -0.96665,1.83183 h -1.122004 v -0.68244 l -1.018446,0.93388 1.018446,0.93387 v -0.70041 h 1.570806 l 0.863079,-1.68816 0.845819,1.68816 h 1.588066 v 0.6645 l 1.018435,-0.89796 -1.018435,-0.93388 v 0.68244 H 42.35 l -0.983911,-1.83183 0.96665,-1.81387 h 1.122003 v 0.61061 l 1.018435,-0.91592 z"
+       stroke="#000000"
+       stroke-width="0.214721"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="69.653313"
+       y="71.402824"
+       
+       transform="scale(0.97023256,1.0306807)">Relay 1<tspan
+   font-size="2.82205px"
+   x="69.832237"
+   y="74.224884"
+   
+   >192.0.2.3</tspan><tspan
+   font-size="2.82205px"
+   x="132.74237"
+   y="71.402824"
+   
+   >Relay 2</tspan><tspan
+   font-size="2.82205px"
+   x="132.92139"
+   y="74.224884"
+   
+   >192.0.2.6</tspan><tspan
+   font-size="2.82205px"
+   x="163.71439"
+   y="67.599197"
+   
+   >Egress 1</tspan><tspan
+   font-size="2.82205px"
+   x="164.46445"
+   y="70.421249"
+   
+   >192.0.2.77</tspan></text>
+    <path
+       d="m 167.32814,61.077146 c 0,-0.35109 -0.26792,-0.63571 -0.59842,-0.63571 h -6.54112 c -0.33051,0 -0.59843,0.28462 -0.59843,0.63571 v 5.55757 c 0,0.35109 0.26792,0.6357 0.59843,0.6357 h 6.54112 c 0.3305,0 0.59842,-0.28461 0.59842,-0.6357 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 165.83352,60.820826 v 0.73632 h -1.58806 l -0.84582,1.65225 -0.86309,-1.65225 h -1.57079 v -0.73632 l -1.01845,0.93387 1.01845,0.93388 v -0.62857 h 1.12199 l 0.96665,1.81387 -0.96665,1.83183 h -1.12199 v -0.68244 l -1.01845,0.93388 1.01845,0.93387 v -0.70041 h 1.57079 l 0.86309,-1.68816 0.84582,1.68816 h 1.58806 v 0.6645 l 1.01844,-0.89796 -1.01844,-0.93388 v 0.68244 h -1.10474 l -0.98391,-1.83183 0.96665,-1.81387 h 1.122 v 0.61061 l 1.01844,-0.91592 z"
+       stroke="#000000"
+       stroke-width="0.214721"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="100.33884"
+       y="83.672615"
+       
+       transform="scale(0.97023256,1.0306807)">Transit 2<tspan
+   font-size="2.82205px"
+   x="101.37522"
+   y="86.494675"
+   
+   >192.0.2.5</tspan></text>
+    <path
+       d="m 106.13875,77.517256 c 0,-0.3511 -0.26792,-0.63571 -0.59842,-0.63571 h -6.54112 c -0.330506,0 -0.598433,0.28461 -0.598433,0.63571 v 5.55757 c 0,0.35109 0.267927,0.6357 0.598433,0.6357 h 6.54112 c 0.3305,0 0.59842,-0.28461 0.59842,-0.6357 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 104.64413,77.387396 v 0.72099 h -1.58806 l -0.84582,1.61782 -0.86308,-1.61782 h -1.570804 v -0.72099 l -1.018449,0.91442 1.018449,0.91442 v -0.61547 h 1.122004 l 0.96664,1.77608 -0.96664,1.79366 h -1.122004 v -0.66822 l -1.018449,0.91442 1.018449,0.91442 v -0.68582 h 1.570804 l 0.86308,-1.65298 0.84582,1.65298 h 1.58806 v 0.65064 l 1.01844,-0.87924 -1.01844,-0.91442 v 0.66822 h -1.10474 l -0.98391,-1.79366 0.96665,-1.77608 h 1.122 v 0.59789 l 1.01844,-0.89684 z"
+       stroke="#000000"
+       stroke-width="0.214721"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="100.33884"
+       y="51.525776"
+       
+       transform="scale(0.97023256,1.0306807)">Transit 1<tspan
+   font-size="2.82205px"
+   x="101.37522"
+   y="54.34782"
+   
+   >192.0.2.4</tspan></text>
+    <path
+       d="m 106.13875,44.510576 c 0,-0.3511 -0.26792,-0.63571 -0.59842,-0.63571 h -6.54112 c -0.330506,0 -0.598433,0.28461 -0.598433,0.63571 v 5.55757 c 0,0.35108 0.267927,0.6357 0.598433,0.6357 h 6.54112 c 0.3305,0 0.59842,-0.28462 0.59842,-0.6357 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 104.64413,44.380716 v 0.72099 h -1.58806 l -0.84582,1.61782 -0.86308,-1.61782 h -1.570804 v -0.72099 l -1.018449,0.91442 1.018449,0.91443 v -0.61548 h 1.122004 l 0.96664,1.77609 -0.96664,1.79367 h -1.122004 v -0.66822 l -1.018449,0.91441 1.018449,0.91442 v -0.68581 h 1.570804 l 0.86308,-1.65299 0.84582,1.65299 h 1.58806 v 0.65064 l 1.01844,-0.87925 -1.01844,-0.91441 v 0.66822 h -1.10474 l -0.98391,-1.79367 0.96665,-1.77609 h 1.122 v 0.59789 l 1.01844,-0.89684 z"
+       stroke="#000000"
+       stroke-width="0.214721"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="192.27025"
+       y="67.599197"
+       
+       transform="scale(0.97023256,1.0306807)">Destination 1<tspan
+   font-size="2.82205px"
+   x="196.00926"
+   y="70.421249"
+   
+   >192.0.2.88</tspan></text>
+    <path
+       d="m 197.92284,61.077146 c 0,-0.35109 -0.26793,-0.63571 -0.59843,-0.63571 h -6.54112 c -0.3305,0 -0.59842,0.28462 -0.59842,0.63571 v 5.55757 c 0,0.35109 0.26792,0.6357 0.59842,0.6357 h 6.54112 c 0.3305,0 0.59843,-0.28461 0.59843,-0.6357 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 196.52971,60.820826 v 0.73632 h -1.61545 l -0.86039,1.65225 -0.87796,-1.65225 h -1.59789 v -0.73632 l -1.03599,0.93387 1.03599,0.93388 v -0.62857 h 1.14135 l 0.98332,1.81387 -0.98332,1.83183 h -1.14135 v -0.68244 l -1.03599,0.93388 1.03599,0.93387 v -0.70041 h 1.59789 l 0.87796,-1.68816 0.86039,1.68816 h 1.61545 v 0.6645 l 1.03599,-0.89796 -1.03599,-0.93388 v 0.68244 h -1.1238 l -1.00087,-1.83183 0.98332,-1.81387 h 1.14135 v 0.61061 l 1.03599,-0.91592 z"
+       stroke="#000000"
+       stroke-width="0.214721"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 14.354661,63.855926 H 37.193545"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 44.94936,63.855926 H 67.78824"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 75.544055,63.811406 98.382934,47.289346"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 106.13875,47.289346 22.83888,16.52206"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 136.73345,63.855926 h 22.83887"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 167.32814,63.855926 h 22.83888"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 106.13875,80.347246 22.83888,-16.49132"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 75.544055,63.855926 22.838879,16.49145"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="16.735573"
+       y="10.362334"
+       width="18.094917"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="21.334379"
+       y="14.716386"
+       
+       transform="scale(0.97023256,1.0306807)">DATA 1</text>
+    <rect
+       x="77.805916"
+       y="39.448677"
+       width="18.094917"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.96317px"
+       
+       x="83.311066"
+       y="41.341846"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS F<tspan
+   font-size="1.96317px"
+   x="90.396866"
+   y="41.341846"
+   
+   >-</tspan><tspan
+   font-size="1.96317px"
+   x="91.219971"
+   y="41.341846"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="86.657852"
+   y="43.795799"
+   
+   >20000</tspan></text>
+    <rect
+       x="77.805916"
+       y="109.88822"
+       width="18.094917"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.96317px"
+       
+       x="83.320015"
+       y="109.80728"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS F<tspan
+   font-size="1.96317px"
+   x="90.40583"
+   y="109.80728"
+   
+   >-</tspan><tspan
+   font-size="1.96317px"
+   x="91.228935"
+   y="109.80728"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="86.666817"
+   y="112.26123"
+   
+   >20001</tspan></text>
+    <rect
+       x="108.40061"
+       y="39.448677"
+       width="18.094917"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.96317px"
+       
+       x="114.84541"
+       y="41.341846"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS F<tspan
+   font-size="1.96317px"
+   x="121.93121"
+   y="41.341846"
+   
+   >-</tspan><tspan
+   font-size="1.96317px"
+   x="122.75431"
+   y="41.341846"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="118.19219"
+   y="43.795799"
+   
+   >20002</tspan></text>
+    <rect
+       x="108.51966"
+       y="109.88822"
+       width="18.094917"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.96317px"
+       
+       x="115.00124"
+       y="109.80728"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS F<tspan
+   font-size="1.96317px"
+   x="122.08704"
+   y="109.80728"
+   
+   >-</tspan><tspan
+   font-size="1.96317px"
+   x="122.91014"
+   y="109.80728"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="118.34802"
+   y="112.26123"
+   
+   >20003</tspan></text>
+    <rect
+       x="169.70906"
+       y="10.362334"
+       width="18.213964"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="179.05692"
+       y="14.716386"
+       
+       transform="scale(0.97023256,1.0306807)">DATA 1</text>
+    <rect
+       x="16.735573"
+       y="17.823614"
+       width="18.094917"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="21.656452"
+       y="20.728594"
+       
+       transform="scale(0.97023256,1.0306807)">IP <tspan
+   font-size="1.96317px"
+   x="25.306725"
+   y="20.728594"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.96317px"
+   x="25.270929"
+   y="23.305248"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="169.70906"
+       y="17.570692"
+       width="18.213964"
+       height="7.3348055"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="179.37961"
+       y="20.483198"
+       
+       transform="scale(0.97023256,1.0306807)">IP <tspan
+   font-size="1.96317px"
+   x="183.02988"
+   y="20.483198"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.96317px"
+   x="182.99408"
+   y="23.059853"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="47.330269"
+       y="24.905508"
+       width="18.094917"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.96317px"
+       
+       x="51.805058"
+       y="27.231581"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS S<tspan
+   font-size="1.96317px"
+   x="58.998222"
+   y="27.231581"
+   
+   >-</tspan><tspan
+   font-size="1.96317px"
+   x="59.821327"
+   y="27.231581"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="56.349998"
+   y="29.685534"
+   
+   >100</tspan></text>
+    <rect
+       x="47.330269"
+       y="32.113853"
+       width="18.094917"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.96317px"
+       
+       x="51.858681"
+       y="34.348064"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS F<tspan
+   font-size="1.96317px"
+   x="58.944485"
+   y="34.348064"
+   
+   >-</tspan><tspan
+   font-size="1.96317px"
+   x="59.767574"
+   y="34.348064"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="55.205456"
+   y="36.802017"
+   
+   >10000</tspan></text>
+    <rect
+       x="47.330269"
+       y="10.362334"
+       width="18.094917"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="52.824921"
+       y="14.716386"
+       
+       transform="scale(0.97023256,1.0306807)">DATA 1</text>
+    <rect
+       x="47.330269"
+       y="17.570692"
+       width="18.094917"
+       height="7.4612679"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="53.147007"
+       y="20.605892"
+       
+       transform="scale(0.97023256,1.0306807)">IP <tspan
+   font-size="1.96317px"
+   x="56.797272"
+   y="20.605892"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.96317px"
+   x="56.761478"
+   y="23.182554"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="139.11435"
+       y="24.905508"
+       width="18.094917"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.96317px"
+       
+       x="146.48798"
+       y="27.231581"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS S<tspan
+   font-size="1.96317px"
+   x="153.68114"
+   y="27.231581"
+   
+   >-</tspan><tspan
+   font-size="1.96317px"
+   x="154.50424"
+   y="27.231581"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="151.0329"
+   y="29.685534"
+   
+   >102</tspan></text>
+    <rect
+       x="139.11435"
+       y="32.113853"
+       width="18.094917"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.96317px"
+       
+       x="146.54195"
+       y="34.348064"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS F<tspan
+   font-size="1.96317px"
+   x="153.62776"
+   y="34.348064"
+   
+   >-</tspan><tspan
+   font-size="1.96317px"
+   x="154.45087"
+   y="34.348064"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="149.88875"
+   y="36.802017"
+   
+   >10005</tspan></text>
+    <rect
+       x="139.11435"
+       y="10.362334"
+       width="18.094917"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="147.50882"
+       y="14.716386"
+       
+       transform="scale(0.97023256,1.0306807)">DATA 1</text>
+    <rect
+       x="139.11435"
+       y="17.570692"
+       width="18.094917"
+       height="7.4612679"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="147.83028"
+       y="20.605892"
+       
+       transform="scale(0.97023256,1.0306807)">IP <tspan
+   font-size="1.96317px"
+   x="151.48055"
+   y="20.605892"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.96317px"
+   x="151.44476"
+   y="23.182554"
+   
+   >192.0.2.88</tspan><tspan
+   font-size="2.82205px"
+   x="5.8307571"
+   y="83.672615"
+   
+   >Source 2</tspan><tspan
+   font-size="2.82205px"
+   x="6.8675623"
+   y="86.494675"
+   
+   >192.0.2.12</tspan></text>
+    <path
+       d="m 14.473711,77.517256 c 0,-0.3511 -0.267927,-0.63571 -0.598433,-0.63571 H 7.2151268 c -0.3305064,0 -0.5984335,0.28461 -0.5984335,0.63571 v 5.55758 c 0,0.3511 0.2679271,0.63572 0.5984335,0.63572 h 6.6601512 c 0.330506,0 0.598433,-0.28462 0.598433,-0.63572 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 12.97909,77.387396 v 0.72099 h -1.588066 l -0.845817,1.61782 -0.8630785,-1.61782 H 8.1113239 v -0.72099 l -1.0184488,0.91442 1.0184488,0.91442 v -0.61547 h 1.1220082 l 0.9666469,1.77608 -0.9666469,1.79366 H 8.1113239 v -0.66822 l -1.0184488,0.91442 1.0184488,0.91442 v -0.68582 h 1.5708046 l 0.8630785,-1.65298 0.845817,1.65298 h 1.588066 v 0.65064 l 1.01844,-0.87924 -1.01844,-0.91442 v 0.66822 h -1.104738 l -0.983908,-1.79366 0.966646,-1.77608 h 1.122 v 0.59789 l 1.01844,-0.89684 z"
+       stroke="#000000"
+       stroke-width="0.214721"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 14.473711,80.296026 H 37.31259"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="16.735573"
+       y="102.67986"
+       width="18.094917"
+       height="7.3347926"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="21.339777"
+       y="104.28587"
+       
+       transform="scale(0.97023256,1.0306807)">DATA 2</text>
+    <rect
+       x="16.735573"
+       y="109.88822"
+       width="18.094917"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="21.661856"
+       y="110.17537"
+       
+       transform="scale(0.97023256,1.0306807)">IP <tspan
+   font-size="1.96317px"
+   x="25.312113"
+   y="110.17537"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.96317px"
+   x="25.276333"
+   y="112.75203"
+   
+   >192.0.2.89</tspan><tspan
+   font-size="2.82205px"
+   x="192.41074"
+   y="83.672615"
+   
+   >Destination 2</tspan><tspan
+   font-size="2.82205px"
+   x="196.15056"
+   y="86.494675"
+   
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 198.04189,77.517256 c 0,-0.3511 -0.26793,-0.63571 -0.59843,-0.63571 h -6.54112 c -0.3305,0 -0.59843,0.28461 -0.59843,0.63571 v 5.55757 c 0,0.35109 0.26793,0.6357 0.59843,0.6357 h 6.54112 c 0.3305,0 0.59843,-0.28461 0.59843,-0.6357 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 196.64876,77.387396 v 0.72099 h -1.61545 l -0.86039,1.61782 -0.87796,-1.61782 h -1.59789 v -0.72099 l -1.03599,0.91442 1.03599,0.91442 v -0.61547 h 1.14135 l 0.98332,1.77608 -0.98332,1.79366 h -1.14135 v -0.66822 l -1.03599,0.91442 1.03599,0.91442 v -0.68582 h 1.59789 l 0.87796,-1.65298 0.86039,1.65298 h 1.61545 v 0.65064 l 1.03599,-0.87924 -1.03599,-0.91442 v 0.66822 h -1.1238 l -1.00087,-1.79366 0.98332,-1.77608 h 1.14135 v 0.59789 l 1.03599,-0.89684 z"
+       stroke="#000000"
+       stroke-width="0.214721"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 167.32814,80.296026 23.0234,0.007"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="169.70906"
+       y="102.67986"
+       width="18.213964"
+       height="7.3347926"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="179.05692"
+       y="104.28587"
+       
+       transform="scale(0.97023256,1.0306807)">DATA 2</text>
+    <rect
+       x="169.70906"
+       y="109.88822"
+       width="18.213964"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="179.37961"
+       y="110.17537"
+       
+       transform="scale(0.97023256,1.0306807)">IP <tspan
+   font-size="1.96317px"
+   x="183.02988"
+   y="110.17537"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.96317px"
+   x="182.99408"
+   y="112.75203"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="47.330269"
+       y="102.67986"
+       width="18.213964"
+       height="7.3347926"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.96317px"
+       
+       x="51.901497"
+       y="102.8135"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS S<tspan
+   font-size="1.96317px"
+   x="59.094662"
+   y="102.8135"
+   
+   >-</tspan><tspan
+   font-size="1.96317px"
+   x="59.917759"
+   y="102.8135"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="56.446438"
+   y="105.26745"
+   
+   >103</tspan></text>
+    <rect
+       x="47.330269"
+       y="88.263161"
+       width="18.213964"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="52.921368"
+       y="90.298302"
+       
+       transform="scale(0.97023256,1.0306807)">DATA 2</text>
+    <rect
+       x="47.330269"
+       y="95.471519"
+       width="18.213964"
+       height="7.3348055"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="53.243446"
+       y="96.065132"
+       
+       transform="scale(0.97023256,1.0306807)">IP <tspan
+   font-size="1.96317px"
+   x="56.893711"
+   y="96.065132"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.96317px"
+   x="56.857914"
+   y="98.641762"
+   
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 45.068405,77.517256 c 0,-0.3511 -0.267923,-0.63571 -0.598422,-0.63571 h -6.541094 c -0.330507,0 -0.59843,0.28461 -0.59843,0.63571 v 5.55755 c 0,0.35109 0.267923,0.63569 0.59843,0.63569 h 6.541094 c 0.330499,0 0.598422,-0.2846 0.598422,-0.63569 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 43.573788,77.387396 v 0.72099 h -1.588067 l -0.845818,1.61782 -0.86308,-1.61782 h -1.570805 v -0.72099 l -1.018446,0.91442 1.018446,0.91442 v -0.61547 h 1.122004 l 0.966649,1.77608 -0.966649,1.79366 h -1.122004 v -0.66822 l -1.018446,0.91442 1.018446,0.91442 v -0.68582 h 1.570805 l 0.86308,-1.65298 0.845818,1.65298 h 1.588067 v 0.65064 l 1.018435,-0.87924 -1.018435,-0.91442 v 0.66822 h -1.104742 l -0.983911,-1.79366 0.96665,-1.77608 h 1.122003 v 0.59789 l 1.018435,-0.89684 z"
+       stroke="#000000"
+       stroke-width="0.214721"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 45.068405,80.347376 67.785502,63.855916"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="37.246216"
+       y="83.672615"
+       
+       transform="scale(0.97023256,1.0306807)">Ingress 2<tspan
+   font-size="2.82205px"
+   x="38.408573"
+   y="86.494675"
+   
+   >192.0.2.23</tspan></text>
+    <path
+       d="m 167.32814,77.517256 c 0,-0.3511 -0.26792,-0.63571 -0.59842,-0.63571 h -6.66016 c -0.33051,0 -0.59844,0.28461 -0.59844,0.63571 v 5.55758 c 0,0.3511 0.26793,0.63572 0.59844,0.63572 h 6.66016 c 0.3305,0 0.59842,-0.28462 0.59842,-0.63572 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 165.83352,77.387396 v 0.72099 h -1.58806 l -0.84582,1.61782 -0.86309,-1.61782 h -1.57079 v -0.72099 l -1.01845,0.91442 1.01845,0.91442 v -0.61547 h 1.12199 l 0.96665,1.77608 -0.96665,1.79366 h -1.12199 v -0.66822 l -1.01845,0.91442 1.01845,0.91442 v -0.68582 h 1.57079 l 0.86309,-1.65298 0.84582,1.65298 h 1.58806 v 0.65064 l 1.01844,-0.87924 -1.01844,-0.91442 v 0.66822 h -1.10474 l -0.98391,-1.79366 0.96665,-1.77608 h 1.122 v 0.59789 l 1.01844,-0.89684 z"
+       stroke="#000000"
+       stroke-width="0.214721"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="163.41905"
+       y="83.672615"
+       
+       transform="scale(0.97023256,1.0306807)">Egress 2<tspan
+   font-size="2.82205px"
+   x="164.16916"
+   y="86.494675"
+   
+   >192.0.2.78</tspan></text>
+    <rect
+       x="47.330269"
+       y="109.88822"
+       width="18.213964"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.96317px"
+       
+       x="51.95512"
+       y="109.80728"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS F<tspan
+   font-size="1.96317px"
+   x="59.04092"
+   y="109.80728"
+   
+   >-</tspan><tspan
+   font-size="1.96317px"
+   x="59.864017"
+   y="109.80728"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="55.874504"
+   y="112.26123"
+   
+   >1006</tspan></text>
+    <path
+       d="m 136.73345,63.855926 22.79007,16.47766"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="139.11435"
+       y="102.67986"
+       width="18.094917"
+       height="7.3347926"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.96317px"
+       
+       x="146.42662"
+       y="102.8135"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS S<tspan
+   font-size="1.96317px"
+   x="153.61978"
+   y="102.8135"
+   
+   >-</tspan><tspan
+   font-size="1.96317px"
+   x="154.4429"
+   y="102.8135"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="150.97156"
+   y="105.26745"
+   
+   >105</tspan></text>
+    <rect
+       x="139.11435"
+       y="88.263161"
+       width="18.094917"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="147.44746"
+       y="90.298302"
+       
+       transform="scale(0.97023256,1.0306807)">DATA 2</text>
+    <rect
+       x="139.11435"
+       y="95.471519"
+       width="18.094917"
+       height="7.3348055"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="147.76894"
+       y="96.065132"
+       
+       transform="scale(0.97023256,1.0306807)">IP <tspan
+   font-size="1.96317px"
+   x="151.4192"
+   y="96.065132"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.96317px"
+   x="151.38342"
+   y="98.641762"
+   
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 35.767975,65.626396 c -0.205472,0 -0.372017,-0.70781 -0.372017,-1.58078 0,-0.8731 0.166545,-1.58078 0.372017,-1.58078 0.205472,0 0.372017,0.70768 0.372017,1.58078 0,0.87297 -0.166545,1.58078 -0.372017,1.58078 H 15.559998 c -0.205473,0 -0.372014,-0.70781 -0.372014,-1.58078 0,-0.8731 0.166541,-1.58078 0.372014,-1.58078 h 20.207977"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="23.085657"
+       y="59.378441"
+       
+       transform="scale(0.97023256,1.0306807)">App-1</text>
+    <path
+       d="m 35.88702,82.066506 c -0.205472,0 -0.372017,-0.70781 -0.372017,-1.58078 0,-0.8731 0.166545,-1.58078 0.372017,-1.58078 0.205472,0 0.372017,0.70768 0.372017,1.58078 0,0.87297 -0.166545,1.58078 -0.372017,1.58078 H 15.679048 c -0.205473,0 -0.372014,-0.70781 -0.372014,-1.58078 0,-0.8731 0.166541,-1.58078 0.372014,-1.58078 H 35.88702"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="22.856083"
+       y="82.568344"
+       
+       transform="scale(0.97023256,1.0306807)">App-2</text>
+    <path
+       d="m 188.74085,65.499926 c -0.20475,0 -0.37141,-0.70768 -0.37141,-1.58077 0,-0.8731 0.16666,-1.58078 0.37141,-1.58078 0.20596,0 0.37262,0.70768 0.37262,1.58078 0,0.87309 -0.16666,1.58077 -0.37262,1.58077 h -20.08893 c -0.20475,0 -0.37141,-0.70768 -0.37141,-1.58077 0,-0.8731 0.16666,-1.58078 0.37141,-1.58078 h 20.08893"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="180.75751"
+       y="59.378441"
+       
+       transform="scale(0.97023256,1.0306807)">App-1</text>
+    <path
+       d="m 188.78609,82.319426 c -0.24642,0 -0.44642,-0.84932 -0.44642,-1.89693 0,-1.04762 0.2,-1.89694 0.44642,-1.89694 0.24643,0 0.44642,0.84932 0.44642,1.89694 0,1.04761 -0.19999,1.89693 -0.44642,1.89693 h -19.94012 c -0.24642,0 -0.44642,-0.84932 -0.44642,-1.89693 0,-1.04762 0.2,-1.89694 0.44642,-1.89694 h 19.94012"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="180.75751"
+       y="82.568344"
+       
+       transform="scale(0.97023256,1.0306807)">App-2</text>
+    <path
+       d="m 65.812085,67.396866 c -0.443802,0 -0.803557,-1.52868 -0.803557,-3.41448 0,-1.88581 0.359755,-3.41449 0.803557,-3.41449 0.443802,0 0.803557,1.52868 0.803557,3.41449 0,1.8858 -0.359755,3.41448 -0.803557,3.41448 H 46.586236 c -0.443802,0 -0.803558,-1.52868 -0.803558,-3.41448 0,-1.88581 0.359756,-3.41449 0.803558,-3.41449 h 19.225849"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="55.499493"
+       y="57.78336"
+       
+       transform="scale(0.97023256,1.0306807)">DN-1</text>
+    <path
+       d="m 68.178114,68.951716 c -0.372612,0.25381 -1.449736,-0.82377 -2.40579,-2.40695 -0.956055,-1.58331 -1.429142,-3.07253 -1.05653,-3.32647 0.372613,-0.25393 1.449737,0.82365 2.405792,2.40696 0.956053,1.58318 1.429141,3.07253 1.056528,3.32646 l -19.488345,13.28045 c -0.372612,0.25394 -1.449736,-0.82365 -2.405791,-2.40695 -0.956054,-1.58319 -1.429022,-3.07254 -1.056528,-3.32635 l 19.488344,-13.28057"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       transform="matrix(0.8166445,-0.55651178,0.52387302,0.86752375,0,0)"
+       
+       x="6.4223285"
+       y="96.823326"
+       >DN<tspan
+   font-size="2.82205px"
+   x="9.9767885"
+   y="96.916885"
+   
+   >-</tspan><tspan
+   font-size="2.82205px"
+   x="10.850277"
+   y="96.894119"
+   
+   >2</tspan></text>
+    <path
+       d="m 157.59617,67.270406 c -0.44405,0 -0.80356,-1.52868 -0.80356,-3.41448 0,-1.88581 0.35951,-3.41449 0.80356,-3.41449 0.44404,0 0.80356,1.52868 0.80356,3.41449 0,1.8858 -0.35952,3.41448 -0.80356,3.41448 h -19.22585 c -0.44404,0 -0.80356,-1.52868 -0.80356,-3.41448 0,-1.88581 0.35952,-3.41449 0.80356,-3.41449 h 19.22585"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="150.25603"
+       y="57.906059"
+       
+       transform="scale(0.97023256,1.0306807)">DN<tspan
+   font-size="2.82205px"
+   x="153.87051"
+   y="57.906059"
+   
+   >-1</tspan></text>
+    <path
+       d="m 156.42,82.195116 c -0.37142,-0.25583 0.10834,-1.74265 1.07141,-3.3209 0.96427,-1.57838 2.04639,-2.6504 2.41781,-2.39457 0.37143,0.25584 -0.10833,1.74266 -1.0726,3.32103 -0.96308,1.57825 -2.0452,2.65027 -2.41662,2.39444 l -19.42704,-13.38124 c -0.37142,-0.25583 0.10833,-1.74265 1.07141,-3.3209 0.96308,-1.57825 2.04521,-2.65027 2.41663,-2.39444 l 19.42822,13.38111"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       transform="matrix(0.81408444,0.56072857,-0.5278425,0.86480419,0,0)"
+       
+       x="164.85442"
+       y="-17.696676"
+       >DN<tspan
+   font-size="2.82205px"
+   x="168.46713"
+   y="-17.699404"
+   
+   >-</tspan><tspan
+   font-size="2.82205px"
+   x="169.33882"
+   y="-17.679663"
+   
+   >2</tspan></text>
+    <path
+       d="m 69.948916,28.572916 c 0,-1.74606 1.30581,-3.16156 2.916615,-3.16156 1.610805,0 2.916615,1.4155 2.916615,3.16156 0,1.74607 -1.30581,3.16156 -2.916615,3.16156 -1.610805,0 -2.916615,-1.41549 -2.916615,-3.16156 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.15331px"
+       
+       x="73.507744"
+       y="29.685534"
+       
+       transform="scale(0.97023256,1.0306807)">R</text>
+    <path
+       d="m 128.63836,28.572916 c 0,-1.74606 1.30592,-3.16156 2.91661,-3.16156 1.61068,0 2.91661,1.4155 2.91661,3.16156 0,1.74607 -1.30593,3.16156 -2.91661,3.16156 -1.61069,0 -2.91661,-1.41549 -2.91661,-3.16156 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.15331px"
+       
+       x="134.25133"
+       y="29.685534"
+       
+       transform="scale(0.97023256,1.0306807)">E</text>
+    <path
+       d="m 69.948916,99.265386 c 0,-1.74607 1.30581,-3.16156 2.916615,-3.16156 1.610805,0 2.916615,1.41549 2.916615,3.16156 0,1.746064 -1.30581,3.161564 -2.916615,3.161564 -1.610805,0 -2.916615,-1.4155 -2.916615,-3.161564 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.15331px"
+       
+       x="73.507744"
+       y="98.273674"
+       
+       transform="scale(0.97023256,1.0306807)">R</text>
+    <path
+       d="m 128.63836,99.455086 c 0,-1.71117 1.30592,-3.09833 2.91661,-3.09833 1.61068,0 2.91661,1.38716 2.91661,3.09833 0,1.711154 -1.30593,3.098324 -2.91661,3.098324 -1.61069,0 -2.91661,-1.38717 -2.91661,-3.098324 z"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.15331px"
+       
+       x="134.25133"
+       y="98.39637"
+       
+       transform="scale(0.97023256,1.0306807)">E</text>
+    <rect
+       x="77.805916"
+       y="24.905508"
+       width="9.0474586"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="82.939163"
+       y="26.1273"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="82.50972"
+   y="27.84507"
+   
+   >S</tspan><tspan
+   font-size="1.47237px"
+   x="83.332825"
+   y="27.84507"
+   
+   >-</tspan><tspan
+   font-size="1.47237px"
+   x="83.941193"
+   y="27.84507"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="83.135277"
+   y="30.176334"
+   
+   >101</tspan></text>
+    <rect
+       x="86.853378"
+       y="24.905508"
+       width="9.0474586"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="92.271935"
+       y="26.1273"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="91.842491"
+   y="27.84507"
+   
+   >S</tspan><tspan
+   font-size="1.47237px"
+   x="92.665596"
+   y="27.84507"
+   
+   >-</tspan><tspan
+   font-size="1.47237px"
+   x="93.273972"
+   y="27.84507"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="92.46804"
+   y="30.176334"
+   
+   >104</tspan></text>
+    <rect
+       x="77.805916"
+       y="17.570692"
+       width="9.0474586"
+       height="7.4612679"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.59507px"
+       
+       x="84.120872"
+       y="19.378916"
+       
+       transform="scale(0.97023256,1.0306807)">IP<tspan
+   font-size="1.59507px"
+   x="82.348694"
+   y="21.219387"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.59507px"
+   x="82.348694"
+   y="23.059853"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="86.853378"
+       y="17.570692"
+       width="9.0474586"
+       height="7.4612679"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.59507px"
+       
+       x="93.453644"
+       y="19.378916"
+       
+       transform="scale(0.97023256,1.0306807)">IP<tspan
+   font-size="1.59507px"
+   x="91.681465"
+   y="21.219387"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.59507px"
+   x="91.681465"
+   y="23.059853"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="77.805916"
+       y="10.362334"
+       width="9.0474586"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.71777px"
+       
+       x="82.491814"
+       y="13.24402"
+       
+       transform="scale(0.97023256,1.0306807)">DATA <tspan
+   font-size="1.71777px"
+   x="84.352715"
+   y="15.329882"
+   
+   >1</tspan></text>
+    <rect
+       x="86.853378"
+       y="10.362334"
+       width="9.0474586"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.71777px"
+       
+       x="91.824577"
+       y="13.24402"
+       
+       transform="scale(0.97023256,1.0306807)">DATA <tspan
+   font-size="1.71777px"
+   x="93.685486"
+   y="15.329882"
+   
+   >2</tspan></text>
+    <rect
+       x="77.805916"
+       y="95.471519"
+       width="9.0474586"
+       height="7.3348055"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="82.947998"
+       y="94.592751"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="82.518555"
+   y="96.310516"
+   
+   >S</tspan><tspan
+   font-size="1.47237px"
+   x="83.341652"
+   y="96.310516"
+   
+   >-</tspan><tspan
+   font-size="1.47237px"
+   x="83.950035"
+   y="96.310516"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="83.144112"
+   y="98.641762"
+   
+   >101</tspan></text>
+    <rect
+       x="86.853378"
+       y="95.471519"
+       width="9.0474586"
+       height="7.3348055"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="92.280769"
+       y="94.592751"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="91.851326"
+   y="96.310516"
+   
+   >S</tspan><tspan
+   font-size="1.47237px"
+   x="92.674431"
+   y="96.310516"
+   
+   >-</tspan><tspan
+   font-size="1.47237px"
+   x="93.282806"
+   y="96.310516"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="92.476891"
+   y="98.641762"
+   
+   >104</tspan></text>
+    <rect
+       x="77.805916"
+       y="88.263161"
+       width="9.0474586"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.59507px"
+       
+       x="84.1297"
+       y="87.967056"
+       
+       transform="scale(0.97023256,1.0306807)">IP<tspan
+   font-size="1.59507px"
+   x="82.357529"
+   y="89.80751"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.59507px"
+   x="82.357529"
+   y="91.64798"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="86.853378"
+       y="88.263161"
+       width="9.0474586"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.59507px"
+       
+       x="93.462471"
+       y="87.967056"
+       
+       transform="scale(0.97023256,1.0306807)">IP<tspan
+   font-size="1.59507px"
+   x="91.6903"
+   y="89.80751"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.59507px"
+   x="91.6903"
+   y="91.64798"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="77.805916"
+       y="80.928337"
+       width="9.0474586"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.71777px"
+       
+       x="82.500641"
+       y="81.832146"
+       
+       transform="scale(0.97023256,1.0306807)">DATA <tspan
+   font-size="1.71777px"
+   x="84.361557"
+   y="83.918022"
+   
+   >1</tspan></text>
+    <rect
+       x="86.853378"
+       y="80.928337"
+       width="9.0474586"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.71777px"
+       
+       x="91.833412"
+       y="81.832146"
+       
+       transform="scale(0.97023256,1.0306807)">DATA <tspan
+   font-size="1.71777px"
+   x="93.694336"
+   y="83.918022"
+   
+   >2</tspan></text>
+    <rect
+       x="108.40061"
+       y="24.905508"
+       width="9.0474586"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="114.47363"
+       y="26.1273"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="114.04419"
+   y="27.84507"
+   
+   >S</tspan><tspan
+   font-size="1.47237px"
+   x="114.86727"
+   y="27.84507"
+   
+   >-</tspan><tspan
+   font-size="1.47237px"
+   x="115.47565"
+   y="27.84507"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="114.66974"
+   y="30.176334"
+   
+   >101</tspan></text>
+    <rect
+       x="117.44807"
+       y="24.905508"
+       width="9.0474701"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="123.80727"
+       y="26.1273"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="123.37782"
+   y="27.84507"
+   
+   >S</tspan><tspan
+   font-size="1.47237px"
+   x="124.2009"
+   y="27.84507"
+   
+   >-</tspan><tspan
+   font-size="1.47237px"
+   x="124.80929"
+   y="27.84507"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="124.00336"
+   y="30.176334"
+   
+   >104</tspan></text>
+    <rect
+       x="108.40061"
+       y="17.570692"
+       width="9.0474586"
+       height="7.4612679"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.59507px"
+       
+       x="115.65521"
+       y="19.378916"
+       
+       transform="scale(0.97023256,1.0306807)">IP<tspan
+   font-size="1.59507px"
+   x="113.88304"
+   y="21.219387"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.59507px"
+   x="113.88304"
+   y="23.059853"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="117.44807"
+       y="17.570692"
+       width="9.0474701"
+       height="7.4612679"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.59507px"
+       
+       x="124.98885"
+       y="19.378916"
+       
+       transform="scale(0.97023256,1.0306807)">IP<tspan
+   font-size="1.59507px"
+   x="123.21667"
+   y="21.219387"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.59507px"
+   x="123.21667"
+   y="23.059853"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="108.40061"
+       y="10.362334"
+       width="9.0474586"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.71777px"
+       
+       x="114.02702"
+       y="13.24402"
+       
+       transform="scale(0.97023256,1.0306807)">DATA <tspan
+   font-size="1.71777px"
+   x="115.88793"
+   y="15.329882"
+   
+   >1</tspan></text>
+    <rect
+       x="117.44807"
+       y="10.362334"
+       width="9.0474701"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.71777px"
+       
+       x="123.35942"
+       y="13.24402"
+       
+       transform="scale(0.97023256,1.0306807)">DATA <tspan
+   font-size="1.71777px"
+   x="125.22034"
+   y="15.329882"
+   
+   >2</tspan></text>
+    <rect
+       x="108.51966"
+       y="95.471519"
+       width="9.0474586"
+       height="7.3348055"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="114.62946"
+       y="94.592751"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="114.20001"
+   y="96.310516"
+   
+   >S</tspan><tspan
+   font-size="1.47237px"
+   x="115.02312"
+   y="96.310516"
+   
+   >-</tspan><tspan
+   font-size="1.47237px"
+   x="115.63151"
+   y="96.310516"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="114.82557"
+   y="98.641762"
+   
+   >101</tspan></text>
+    <rect
+       x="117.56711"
+       y="95.471519"
+       width="9.0474586"
+       height="7.3348055"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="123.96309"
+       y="94.592751"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="123.53365"
+   y="96.310516"
+   
+   >S</tspan><tspan
+   font-size="1.47237px"
+   x="124.35675"
+   y="96.310516"
+   
+   >-</tspan><tspan
+   font-size="1.47237px"
+   x="124.96513"
+   y="96.310516"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="124.15921"
+   y="98.641762"
+   
+   >104</tspan></text>
+    <rect
+       x="108.51966"
+       y="88.136696"
+       width="9.0474586"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.59507px"
+       
+       x="115.81104"
+       y="87.844353"
+       
+       transform="scale(0.97023256,1.0306807)">IP<tspan
+   font-size="1.59507px"
+   x="114.03887"
+   y="89.684822"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.59507px"
+   x="114.03887"
+   y="91.525284"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="117.56711"
+       y="88.136696"
+       width="9.0474586"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.59507px"
+       
+       x="125.14467"
+       y="87.844353"
+       
+       transform="scale(0.97023256,1.0306807)">IP<tspan
+   font-size="1.59507px"
+   x="123.37249"
+   y="89.684822"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.59507px"
+   x="123.37249"
+   y="91.525284"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="108.51966"
+       y="80.928337"
+       width="9.0474586"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.71777px"
+       
+       x="114.18284"
+       y="81.709457"
+       
+       transform="scale(0.97023256,1.0306807)">DATA <tspan
+   font-size="1.71777px"
+   x="116.04375"
+   y="83.795319"
+   
+   >1</tspan></text>
+    <rect
+       x="117.56711"
+       y="80.928337"
+       width="9.0474586"
+       height="7.3348303"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.71777px"
+       
+       x="123.51524"
+       y="81.709457"
+       
+       transform="scale(0.97023256,1.0306807)">DATA <tspan
+   font-size="1.71777px"
+   x="125.37616"
+   y="83.795319"
+   
+   >2</tspan></text>
+    <rect
+       x="77.805916"
+       y="32.113853"
+       width="9.0474586"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="82.939896"
+       y="33.366478"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="82.546242"
+   y="35.084248"
+   
+   >F-</tspan><tspan
+   font-size="1.47237px"
+   x="83.906143"
+   y="35.084248"
+   
+   >label</tspan><tspan
+   font-size="1.71777px"
+   x="82.348694"
+   y="37.170109"
+   
+   >10003</tspan></text>
+    <rect
+       x="86.853378"
+       y="32.113853"
+       width="9.0474586"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="92.272667"
+       y="33.366478"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="91.879013"
+   y="35.084248"
+   
+   >F-</tspan><tspan
+   font-size="1.47237px"
+   x="93.238914"
+   y="35.084248"
+   
+   >label</tspan><tspan
+   font-size="1.71777px"
+   x="91.681473"
+   y="37.170109"
+   
+   >10009</tspan></text>
+    <rect
+       x="77.805916"
+       y="102.67986"
+       width="9.0474586"
+       height="7.3347926"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="82.948738"
+       y="101.83191"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="82.555077"
+   y="103.54967"
+   
+   >F-</tspan><tspan
+   font-size="1.47237px"
+   x="83.914986"
+   y="103.54967"
+   
+   >label</tspan><tspan
+   font-size="1.71777px"
+   x="82.357529"
+   y="105.63554"
+   
+   >10004</tspan></text>
+    <rect
+       x="86.853378"
+       y="102.67986"
+       width="9.0474586"
+       height="7.3347926"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="92.281509"
+       y="101.83191"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="91.887848"
+   y="103.54967"
+   
+   >F-</tspan><tspan
+   font-size="1.47237px"
+   x="93.247749"
+   y="103.54967"
+   
+   >label</tspan><tspan
+   font-size="1.71777px"
+   x="91.6903"
+   y="105.63554"
+   
+   >10010</tspan></text>
+    <rect
+       x="108.40061"
+       y="32.113853"
+       width="9.0474586"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="114.47485"
+       y="33.366478"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="114.08119"
+   y="35.084248"
+   
+   >F-</tspan><tspan
+   font-size="1.47237px"
+   x="115.44111"
+   y="35.084248"
+   
+   >label</tspan><tspan
+   font-size="1.71777px"
+   x="113.88365"
+   y="37.170109"
+   
+   >10003</tspan></text>
+    <rect
+       x="117.44807"
+       y="32.113853"
+       width="9.0474701"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="123.80727"
+       y="33.366478"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="123.4136"
+   y="35.084248"
+   
+   >F-</tspan><tspan
+   font-size="1.47237px"
+   x="124.77351"
+   y="35.084248"
+   
+   >label</tspan><tspan
+   font-size="1.71777px"
+   x="123.21605"
+   y="37.170109"
+   
+   >10009</tspan></text>
+    <rect
+       x="108.51966"
+       y="102.67986"
+       width="9.0474586"
+       height="7.3347926"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="114.63069"
+       y="101.83191"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="114.23704"
+   y="103.54967"
+   
+   >F-</tspan><tspan
+   font-size="1.47237px"
+   x="115.59693"
+   y="103.54967"
+   
+   >label</tspan><tspan
+   font-size="1.71777px"
+   x="114.0395"
+   y="105.63554"
+   
+   >10004</tspan></text>
+    <rect
+       x="117.56711"
+       y="102.67986"
+       width="9.0474586"
+       height="7.3347926"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.47237px"
+       
+       x="123.96309"
+       y="101.83191"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS<tspan
+   font-size="1.47237px"
+   x="123.56944"
+   y="103.54967"
+   
+   >F-</tspan><tspan
+   font-size="1.47237px"
+   x="124.92934"
+   y="103.54967"
+   
+   >label</tspan><tspan
+   font-size="1.71777px"
+   x="123.37189"
+   y="105.63554"
+   
+   >10010</tspan></text>
+    <rect
+       x="139.11435"
+       y="109.88822"
+       width="18.094917"
+       height="7.4612932"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.96317px"
+       
+       x="146.48062"
+       y="109.80728"
+       
+       transform="scale(0.97023256,1.0306807)">MPLS F<tspan
+   font-size="1.96317px"
+   x="153.56641"
+   y="109.80728"
+   
+   >-</tspan><tspan
+   font-size="1.96317px"
+   x="154.38951"
+   y="109.80728"
+   
+   >label</tspan><tspan
+   font-size="1.96317px"
+   x="149.82739"
+   y="112.26123"
+   
+   >10011</tspan><tspan
+   font-size="4.04903px"
+   x="167.5692"
+   y="44.777386"
+   
+   >Note: S-label in this</tspan><tspan
+   font-size="4.04903px"
+   x="167.5692"
+   y="49.562603"
+   
+   >diagram includes d-CW.</tspan></text>
+    <path
+       d="m 74.502406,63.602996 c -0.443801,0 -0.803557,-1.52868 -0.803557,-3.41448 0,-1.88581 0.359756,-3.41449 0.803557,-3.41449 0.443802,0 0.803558,1.52868 0.803558,3.41449 0,1.8858 -0.359756,3.41448 -0.803558,3.41448 H 68.7287 c -0.443802,0 -0.803557,-1.52868 -0.803557,-3.41448 0,-1.88581 0.359755,-3.41449 0.803557,-3.41449 h 5.773706"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="71.532921"
+       y="58.396854"
+       
+       transform="scale(0.97023256,1.0306807)">DN<tspan
+   font-size="2.82205px"
+   x="75.147392"
+   y="58.396854"
+   
+   >-1</tspan></text>
+    <path
+       d="m 74.264315,70.937816 c -0.443801,0 -0.803557,-1.52868 -0.803557,-3.41448 0,-1.88581 0.359756,-3.41449 0.803557,-3.41449 0.443802,0 0.803557,1.52868 0.803557,3.41449 0,1.8858 -0.359755,3.41448 -0.803557,3.41448 h -5.654661 c -0.443802,0 -0.803557,-1.52868 -0.803557,-3.41448 0,-1.88581 0.359755,-3.41449 0.803557,-3.41449 h 5.654661"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="71.501755"
+       y="67.844582"
+       
+       transform="scale(0.97023256,1.0306807)">DN<tspan
+   font-size="2.82205px"
+   x="75.116234"
+   y="67.844582"
+   
+   >-2</tspan></text>
+    <path
+       d="m 127.83479,70.811346 c -0.90355,0 -1.63687,-3.11401 -1.63687,-6.95542 0,-3.84143 0.73332,-6.95544 1.63687,-6.95544 0.90356,0 1.63688,3.11401 1.63688,6.95544 0,3.84141 -0.73332,6.95542 -1.63688,6.95542 H 77.419021 c -0.904031,0 -1.636875,-3.11401 -1.636875,-6.95542 0,-3.84143 0.732844,-6.95544 1.636875,-6.95544 h 50.415769"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="99.455414"
+       y="63.059364"
+       
+       transform="scale(0.97023256,1.0306807)">DN<tspan
+   font-size="2.82205px"
+   x="103.06989"
+   y="63.059364"
+   
+   >-1 / DN</tspan><tspan
+   font-size="2.82205px"
+   x="111.40823"
+   y="63.059364"
+   
+   >-2</tspan></text>
+    <path
+       d="m 135.81084,63.729456 c -0.44404,0 -0.80356,-1.52867 -0.80356,-3.41448 0,-1.88581 0.35952,-3.41449 0.80356,-3.41449 0.44405,0 0.80356,1.52868 0.80356,3.41449 0,1.88581 -0.35951,3.41448 -0.80356,3.41448 h -5.65466 c -0.44404,0 -0.80355,-1.52867 -0.80355,-3.41448 0,-1.88581 0.35951,-3.41449 0.80355,-3.41449 h 5.65466"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="135.00713"
+       y="58.396854"
+       
+       transform="scale(0.97023256,1.0306807)">DN<tspan
+   font-size="2.82205px"
+   x="138.6216"
+   y="58.396854"
+   
+   >-1</tspan></text>
+    <path
+       d="m 135.6918,70.937816 c -0.44405,0 -0.80356,-1.52868 -0.80356,-3.41448 0,-1.88581 0.35951,-3.41449 0.80356,-3.41449 0.44404,0 0.80356,1.52868 0.80356,3.41449 0,1.8858 -0.35952,3.41448 -0.80356,3.41448 h -5.65466 c -0.44405,0 -0.80356,-1.52868 -0.80356,-3.41448 0,-1.88581 0.35951,-3.41449 0.80356,-3.41449 h 5.65466"
+       stroke="#000000"
+       stroke-width="0.286295"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="134.7691"
+       y="68.089989"
+       
+       transform="scale(0.97023256,1.0306807)">DN<tspan
+   font-size="2.82205px"
+   x="138.38356"
+   y="68.089989"
+   
+   >-2</tspan></text>
+    <path
+       d="m 63.341891,55.760816 c 0,-0.31338 0.239162,-0.56757 0.534275,-0.56757 H 79.35494 c 0.294994,0 0.534276,0.25419 0.534276,0.56757 v 17.45484 c 0,0.3135 -0.239282,0.56756 -0.534276,0.56756 H 63.876166 c -0.295113,0 -0.534275,-0.25406 -0.534275,-0.56756 z"
+       stroke="#000000"
+       stroke-width="0.572589"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.29036, 1.71777"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 124.17414,55.789396 c 0,-0.32919 0.25119,-0.59615 0.56071,-0.59615 h 16.25924 c 0.30951,0 0.5607,0.26696 0.5607,0.59615 v 17.27121 c 0,0.32919 -0.25119,0.59615 -0.5607,0.59615 h -16.25924 c -0.30952,0 -0.56071,-0.26696 -0.56071,-0.59615 z"
+       stroke="#000000"
+       stroke-width="0.572589"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.29036, 1.71777"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.82205px"
+       
+       x="66.964508"
+       y="77.169632"
+       
+       transform="scale(0.97023256,1.0306807)">aggregation<tspan
+   font-size="2.82205px"
+   x="128.42525"
+   y="77.169632"
+   
+   >disaggregation</tspan></text>
+  </g>
+</svg>
+</artwork>
+</artset>
+        </figure>
+        <figure anchor="example-detnet-json-service-aggregation-c-1">
+          <name>Example C-1 DetNet JSON Relay Service Aggregation</name>
+          <artwork name="" type="" align="left" alt=""><![CDATA[
+{
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "eth0",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth1",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth2",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth3",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth4",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      }
+    ]
+  },
+  "ietf-detnet:detnet": {
+    "traffic-profile": [
+      {
+        "profile-name": "pf-1",
+        "traffic-requirements": {
+          "min-bandwidth": "100000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 100000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "member-services": [
+          "ssl-1",
+          "ssl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-2",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 2,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "afl-1",
+          "afl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-3",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 1,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "fsl-1",
+          "fsl-2",
+          "fsl-3",
+          "fsl-4",
+          "fsl-5",
+          "fsl-6"
+        ]
+      }
+    ],
+    "service-sub-layer": {
+      "service-sub-layer-list": [
+        {
+          "name": "ssl-1",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "replication",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 100
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 101
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-2",
+                    "fsl-3"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "ssl-2",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "replication",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 103
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 104
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-5",
+                    "fsl-6"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "forwarding-sub-layer": {
+      "forwarding-sub-layer-list": [
+        {
+          "name": "fsl-1",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth0",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10000
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-2",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "aggregation-forwarding-sub-layer": "afl-1",
+              "forwarding-label": {
+                "mpls-label-stack": {
+                  "entry": [
+                    {
+                      "id": 0,
+                      "label": 10003
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "fsl-3",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "aggregation-forwarding-sub-layer": "afl-2",
+              "forwarding-label": {
+                "mpls-label-stack": {
+                  "entry": [
+                    {
+                      "id": 0,
+                      "label": 10004
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "fsl-4",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10006
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-2"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-5",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-2"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "aggregation-forwarding-sub-layer": "afl-1",
+              "forwarding-label": {
+                "mpls-label-stack": {
+                  "entry": [
+                    {
+                      "id": 0,
+                      "label": 10009
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "fsl-6",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-2"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "aggregation-forwarding-sub-layer": "afl-2",
+              "forwarding-label": {
+                "mpls-label-stack": {
+                  "entry": [
+                    {
+                      "id": 0,
+                      "label": 10010
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "afl-1",
+          "traffic-profile": "pf-2",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "forwarding-aggregation": {
+              "forwarding-sub-layer": [
+                "fsl-2",
+                "fsl-5"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth2",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20000
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "afl-2",
+          "traffic-profile": "pf-2",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "forwarding-aggregation": {
+              "forwarding-sub-layer": [
+                "fsl-3",
+                "fsl-6"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth3",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20001
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+]]></artwork>
+        </figure>
+        <figure anchor="example-detnet-json-service-disaggregation-c-1">
+          <name>Example C-1 DetNet JSON Relay Service Disaggregation</name>
+          <artwork name="" type="" align="left" alt=""><![CDATA[
+{
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "eth0",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth1",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth2",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth3",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth4",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      }
+    ]
+  },
+  "ietf-detnet:detnet": {
+    "traffic-profile": [
+      {
+        "profile-name": "pf-1",
+        "traffic-requirements": {
+          "min-bandwidth": "100000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 100000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "member-services": [
+          "ssl-1",
+          "ssl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-2",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 2,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "afl-1",
+          "afl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-3",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 1,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "fsl-1",
+          "fsl-2",
+          "fsl-3",
+          "fsl-4",
+          "fsl-5",
+          "fsl-6"
+        ]
+      }
+    ],
+    "service-sub-layer": {
+      "service-sub-layer-list": [
+        {
+          "name": "ssl-1",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "elimination",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 101
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 102
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-3"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "ssl-2",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "elimination",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 104
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 105
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-6"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "forwarding-sub-layer": {
+      "forwarding-sub-layer-list": [
+        {
+          "name": "afl-1",
+          "traffic-profile": "pf-2",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth0",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20002
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-disaggregation": {
+              "forwarding-sub-layer": [
+                "fsl-1",
+                "fsl-4"
+              ]
+            }
+          }
+        },
+        {
+          "name": "afl-2",
+          "traffic-profile": "pf-2",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20003
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-disaggregation": {
+              "forwarding-sub-layer": [
+                "fsl-2",
+                "fsl-5"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-1",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth0",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10003
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-2",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10004
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-3",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth2",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10005
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "fsl-4",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth0",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10009
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-2"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-5",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10010
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-2"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-6",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-2"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth3",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10011
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+]]></artwork>
+        </figure>
+      </section>
+      <section numbered="true" toc="default">
+        <name>Example C-2 JSON Relay Aggregation Service Sub-Layer</name>
+        <t>
+                This illustrates the Relay node 1 aggregating the service sub-layers 
+                of DetNet flows 1 and 2 into a forwarding sub-layer
+                A diagram illustrating both aggregation and disaggregation is shown and then the 
+                corresponding JSON operational data follows.
+        </t>
+        <figure anchor="case-c2">
+                <name>Case C-2 Example JSON Service Aggregation/Disaggregation</name>
+          <artset>
+            <artwork align="left" type="ascii-art" name="" alt=""><![CDATA[
+        
+Please consult the PDF or HTML versions for the Case C-2 Diagram.
+
+]]></artwork>
+        <artwork type="svg">
+<svg
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="210mm"
+   height="120mm"
+   viewBox="0 15 210 110"
+   version="1.1"
+   >
+  <g
+     >
+    <path
+       d="m 133.60458,66.251046 c 0,-0.453159 -0.25927,-0.820516 -0.57909,-0.820516 h -6.32985 c -0.31982,0 -0.5791,0.367357 -0.5791,0.820516 v 7.173219 c 0,0.453164 0.25928,0.820523 0.5791,0.820523 h 6.32985 c 0.31982,0 0.57909,-0.367359 0.57909,-0.820523 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 132.38864,65.920211 v 0.950386 h -1.53677 l -0.81849,2.132582 -0.8352,-2.132582 h -1.52008 v -0.950386 l -0.98554,1.205369 0.98554,1.205365 v -0.811303 h 1.08577 l 0.93543,2.341193 -0.93543,2.364382 h -1.08577 v -0.88084 l -0.98554,1.205364 0.98554,1.205366 v -0.904031 h 1.52008 l 0.8352,-2.178933 0.81849,2.178933 h 1.53677 v 0.857675 l 0.98554,-1.15901 -0.98554,-1.205364 v 0.88084 h -1.06906 l -0.95212,-2.364382 0.93542,-2.341193 h 1.08576 v 0.788125 l 0.98554,-1.182187 z"
+       stroke="#000000"
+       stroke-width="0.239973"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="7.7717557"
+       y="65.252716"
+       
+       transform="scale(0.84010005,1.1903344)">Source 1<tspan
+   font-size="3.15392px"
+   x="8.9300222"
+   y="68.406639"
+   
+   >192.0.2.1</tspan></text>
+    <path
+       d="m 15.063329,66.577505 c 0,-0.453162 -0.25927,-0.820521 -0.579096,-0.820521 H 8.0392134 c -0.3198313,0 -0.5791011,0.367359 -0.5791011,0.820521 v 7.173247 c 0,0.453153 0.2592698,0.820511 0.5791011,0.820511 h 6.4450196 c 0.319826,0 0.579096,-0.367358 0.579096,-0.820511 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 13.732187,66.246666 v 0.950386 h -1.536773 l -0.818499,2.132583 -0.835204,-2.132583 H 9.0216421 v -0.950386 l -0.9855517,1.205368 0.9855517,1.205367 v -0.811306 h 1.0857639 l 0.935428,2.341196 -0.935428,2.364375 H 9.0216421 v -0.880833 l -0.9855517,1.205365 0.9855517,1.205365 v -0.904031 h 1.5200689 l 0.835204,-2.178934 0.818499,2.178934 h 1.536773 v 0.857675 l 0.98554,-1.159009 -0.98554,-1.205365 v 0.880833 h -1.069059 l -0.952132,-2.364375 0.935428,-2.341196 h 1.085763 v 0.788122 l 0.98554,-1.182183 z"
+       stroke="#000000"
+       stroke-width="0.239973"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="42.885876"
+       y="65.252716"
+       
+       transform="scale(0.84010005,1.1903344)">Ingress 1<tspan
+   font-size="3.15392px"
+   x="44.184929"
+   y="68.406639"
+   
+   >192.0.2.2</tspan></text>
+    <path
+       d="m 44.669843,66.57751 c 0,-0.453164 -0.259273,-0.820526 -0.579102,-0.820526 h -6.329815 c -0.319831,0 -0.579101,0.367362 -0.579101,0.820526 v 7.173223 c 0,0.453172 0.25927,0.82053 0.579101,0.82053 h 6.329815 c 0.319829,0 0.579102,-0.367358 0.579102,-0.82053 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 43.223499,66.246666 v 0.950386 h -1.536772 l -0.8185,2.132583 -0.835202,-2.132583 h -1.52007 v -0.950386 l -0.985551,1.205368 0.985551,1.205367 v -0.811306 h 1.085764 l 0.935427,2.341196 -0.935427,2.364375 h -1.085764 v -0.880833 l -0.985551,1.205365 0.985551,1.205365 v -0.904031 h 1.52007 l 0.835202,-2.178934 0.8185,2.178934 h 1.536772 v 0.857675 l 0.985541,-1.159009 -0.985541,-1.205365 v 0.880833 H 42.15444 l -0.952131,-2.364375 0.935427,-2.341196 h 1.085763 v 0.788122 l 0.985541,-1.182183 z"
+       stroke="#000000"
+       stroke-width="0.239973"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="79.239899"
+       y="69.092278"
+       
+       transform="scale(0.84010005,1.1903344)">Relay 1<tspan
+   font-size="3.15392px"
+   x="79.43988"
+   y="72.246201"
+   
+   >192.0.2.3</tspan><tspan
+   font-size="3.15392px"
+   x="149.74815"
+   y="69.092278"
+   
+   >Relay 2</tspan><tspan
+   font-size="3.15392px"
+   x="149.94823"
+   y="72.246201"
+   
+   >192.0.2.6</tspan><tspan
+   font-size="3.15392px"
+   x="184.36246"
+   y="65.252724"
+   
+   >Egress 1</tspan><tspan
+   font-size="3.15392px"
+   x="185.20071"
+   y="68.406639"
+   
+   >192.0.2.77</tspan></text>
+    <path
+       d="m 163.09589,66.577502 c 0,-0.453159 -0.25927,-0.820518 -0.57909,-0.820518 h -6.32985 c -0.31982,0 -0.57909,0.367359 -0.57909,0.820518 v 7.173219 c 0,0.453165 0.25927,0.820523 0.57909,0.820523 h 6.32985 c 0.31982,0 0.57909,-0.367358 0.57909,-0.820523 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 161.87995,66.246666 v 0.950386 h -1.53677 l -0.8185,2.132583 -0.83521,-2.132583 h -1.52006 v -0.950386 l -0.98555,1.205368 0.98555,1.205367 v -0.811306 h 1.08576 l 0.93543,2.341196 -0.93543,2.364375 h -1.08576 v -0.880833 l -0.98555,1.205365 0.98555,1.205365 v -0.904031 h 1.52006 l 0.83521,-2.178934 0.8185,2.178934 h 1.53677 v 0.857675 l 0.98554,-1.159009 -0.98554,-1.205365 v 0.880833 h -1.06905 l -0.95214,-2.364375 0.93543,-2.341196 h 1.08576 v 0.788122 l 0.98554,-1.182183 z"
+       stroke="#000000"
+       stroke-width="0.239973"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="113.53401"
+       y="83.216354"
+       
+       transform="scale(0.84010005,1.1903344)">Transit 2<tspan
+   font-size="3.15392px"
+   x="114.69227"
+   y="86.370277"
+   
+   >192.0.2.5</tspan></text>
+    <path
+       d="m 103.88287,87.797014 c 0,-0.453159 -0.25927,-0.820517 -0.5791,-0.820517 h -6.329843 c -0.319825,0 -0.579095,0.367358 -0.579095,0.820517 v 7.173228 c 0,0.453162 0.25927,0.820519 0.579095,0.820519 h 6.329843 c 0.31983,0 0.5791,-0.367357 0.5791,-0.820519 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 102.64994,87.62941 v 0.930588 h -1.56328 l -0.83259,2.088152 -0.849603,-2.088152 H 97.858191 V 87.62941 l -1.00254,1.180256 1.00254,1.180248 V 89.19552 h 1.10448 l 0.951551,2.29242 -0.951551,2.315117 h -1.10448 v -0.862498 l -1.00254,1.180267 1.00254,1.180258 v -0.885198 h 1.546276 l 0.849603,-2.133538 0.83259,2.133538 h 1.56328 v 0.839789 l 1.00253,-1.134849 -1.00253,-1.180267 v 0.862498 h -1.08749 l -0.96855,-2.315117 0.95155,-2.29242 h 1.10449 v 0.771703 l 1.00253,-1.157557 z"
+       stroke="#000000"
+       stroke-width="0.239973"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="113.53401"
+       y="47.289078"
+       
+       transform="scale(0.84010005,1.1903344)">Transit 1<tspan
+   font-size="3.15392px"
+   x="114.69227"
+   y="50.442997"
+   
+   >192.0.2.4</tspan></text>
+    <path
+       d="m 103.88287,45.194758 c 0,-0.453159 -0.25927,-0.820516 -0.5791,-0.820516 h -6.329843 c -0.319825,0 -0.579095,0.367357 -0.579095,0.820516 v 7.173218 c 0,0.453168 0.25927,0.820526 0.579095,0.820526 h 6.329843 c 0.31983,0 0.5791,-0.367358 0.5791,-0.820526 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 102.64994,45.02715 v 0.930589 h -1.56328 l -0.83259,2.088148 -0.849603,-2.088148 H 97.858191 V 45.02715 l -1.00254,1.18026 1.00254,1.180264 v -0.79441 h 1.10448 l 0.951551,2.292426 -0.951551,2.315131 h -1.10448 v -0.862492 l -1.00254,1.180246 1.00254,1.180262 v -0.885196 h 1.546276 l 0.849603,-2.133542 0.83259,2.133542 h 1.56328 v 0.839803 l 1.00253,-1.134869 -1.00253,-1.180246 v 0.862492 h -1.08749 l -0.96855,-2.315131 0.95155,-2.292426 h 1.10449 v 0.771705 l 1.00253,-1.157559 z"
+       stroke="#000000"
+       stroke-width="0.239973"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="216.27646"
+       y="65.252716"
+       
+       transform="scale(0.84010005,1.1903344)">Destination 1<tspan
+   font-size="3.15392px"
+   x="220.45518"
+   y="68.406639"
+   
+   >192.0.2.88</tspan></text>
+    <path
+       d="m 192.70241,66.577502 c 0,-0.453159 -0.25927,-0.820518 -0.5791,-0.820518 h -6.32984 c -0.31983,0 -0.5791,0.367359 -0.5791,0.820518 v 7.173219 c 0,0.453165 0.25927,0.820523 0.5791,0.820523 h 6.32984 c 0.31983,0 0.5791,-0.367358 0.5791,-0.820523 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 191.48647,66.246666 v 0.950386 h -1.53678 l -0.8185,2.132583 -0.8352,-2.132583 h -1.52007 v -0.950386 l -0.98555,1.205368 0.98555,1.205367 v -0.811306 h 1.08577 l 0.93542,2.341196 -0.93542,2.364375 h -1.08577 v -0.880833 l -0.98555,1.205365 0.98555,1.205365 v -0.904031 h 1.52007 l 0.8352,-2.178934 0.8185,2.178934 h 1.53678 v 0.857675 l 0.98554,-1.159009 -0.98554,-1.205365 v 0.880833 h -1.06906 l -0.95213,-2.364375 0.93542,-2.341196 h 1.08577 v 0.788122 l 0.98554,-1.182183 z"
+       stroke="#000000"
+       stroke-width="0.239973"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 15.063329,70.164114 H 37.164534"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 44.669843,70.164114 H 66.771047"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 74.276355,70.10666 96.37756,48.781373"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 103.88287,48.781371 22.1012,21.325289"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 133.48938,70.164114 h 22.10121"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 163.09589,70.164114 H 185.1971"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 103.88287,91.449736 22.1012,-21.285622"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 74.276355,70.164114 96.37756,91.449895"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="17.367334"
+       y="10.259789"
+       width="17.510468"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="25.238726"
+       y="13.830078"
+       
+       transform="scale(0.84010005,1.1903344)">DATA 1</text>
+    <rect
+       x="76.580368"
+       y="38.661297"
+       width="17.510468"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.19403px"
+       
+       x="94.622543"
+       y="35.907528"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS F<tspan
+   font-size="2.19403px"
+   x="102.54163"
+   y="35.907528"
+   
+   >-</tspan><tspan
+   font-size="2.19403px"
+   x="103.46153"
+   y="35.907528"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="98.362923"
+   y="38.65007"
+   
+   >20000</tspan></text>
+    <rect
+       x="76.465164"
+       y="119.94836"
+       width="17.510468"
+       height="9.4671688"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.19403px"
+       
+       x="94.513802"
+       y="104.19681"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS F<tspan
+   font-size="2.19403px"
+   x="102.43288"
+   y="104.19681"
+   
+   >-</tspan><tspan
+   font-size="2.19403px"
+   x="103.35279"
+   y="104.19681"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="98.254173"
+   y="106.93934"
+   
+   >20001</tspan></text>
+    <rect
+       x="106.18688"
+       y="38.661297"
+       width="17.510468"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.19403px"
+       
+       x="129.85487"
+       y="35.907528"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS F<tspan
+   font-size="2.19403px"
+   x="137.77396"
+   y="35.907528"
+   
+   >-</tspan><tspan
+   font-size="2.19403px"
+   x="138.69386"
+   y="35.907528"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="133.59525"
+   y="38.65007"
+   
+   >20002</tspan></text>
+    <rect
+       x="106.18688"
+       y="119.94836"
+       width="17.510468"
+       height="9.4671688"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.19403px"
+       
+       x="129.92068"
+       y="104.19681"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS F<tspan
+   font-size="2.19403px"
+   x="137.83978"
+   y="104.19681"
+   
+   >-</tspan><tspan
+   font-size="2.19403px"
+   x="138.75969"
+   y="104.19681"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="133.66106"
+   y="106.93934"
+   
+   >20003</tspan></text>
+    <rect
+       x="165.16951"
+       y="10.259789"
+       width="17.510468"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="201.73962"
+       y="13.830078"
+       
+       transform="scale(0.84010005,1.1903344)">DATA1</text>
+    <rect
+       x="17.367334"
+       y="19.726957"
+       width="17.510468"
+       height="9.4671526"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="25.598682"
+       y="20.412176"
+       
+       transform="scale(0.84010005,1.1903344)">IP <tspan
+   font-size="2.19403px"
+   x="29.678211"
+   y="20.412176"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="2.19403px"
+   x="29.638214"
+   y="23.291843"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="165.16951"
+       y="19.726957"
+       width="17.510468"
+       height="9.4671526"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="201.53941"
+       y="20.412176"
+       
+       transform="scale(0.84010005,1.1903344)">IP <tspan
+   font-size="2.19403px"
+   x="205.61893"
+   y="20.412176"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="2.19403px"
+   x="205.57893"
+   y="23.291843"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="46.97385"
+       y="29.194126"
+       width="17.510468"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.19403px"
+       
+       x="59.347977"
+       y="27.954165"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS S<tspan
+   font-size="2.19403px"
+   x="67.387047"
+   y="27.954165"
+   
+   >-</tspan><tspan
+   font-size="2.19403px"
+   x="68.306938"
+   y="27.954165"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="64.427383"
+   y="30.696703"
+   
+   >100</tspan></text>
+    <rect
+       x="46.97385"
+       y="38.661297"
+       width="17.510468"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.19403px"
+       
+       x="59.407898"
+       y="35.907528"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS F<tspan
+   font-size="2.19403px"
+   x="67.326988"
+   y="35.907528"
+   
+   >-</tspan><tspan
+   font-size="2.19403px"
+   x="68.24688"
+   y="35.907528"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="63.148277"
+   y="38.65007"
+   
+   >10000</tspan></text>
+    <rect
+       x="46.97385"
+       y="10.259789"
+       width="17.510468"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="60.487778"
+       y="13.830078"
+       
+       transform="scale(0.84010005,1.1903344)">DATA 1</text>
+    <rect
+       x="46.97385"
+       y="19.726957"
+       width="17.510468"
+       height="9.4671526"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="60.847736"
+       y="20.412176"
+       
+       transform="scale(0.84010005,1.1903344)">IP <tspan
+   font-size="2.19403px"
+   x="64.927261"
+   y="20.412176"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="2.19403px"
+   x="64.887268"
+   y="23.291843"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="135.7934"
+       y="29.194126"
+       width="17.510468"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.19403px"
+       
+       x="169.13216"
+       y="27.954165"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS<tspan
+   font-size="2.19403px"
+   x="166.1725"
+   y="30.696703"
+   
+   >S</tspan><tspan
+   font-size="2.19403px"
+   x="167.45236"
+   y="30.696703"
+   
+   >-</tspan><tspan
+   font-size="2.19403px"
+   x="168.37225"
+   y="30.696703"
+   
+   >label 102</tspan></text>
+    <rect
+       x="135.7934"
+       y="38.661297"
+       width="17.510468"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.19403px"
+       
+       x="165.17194"
+       y="35.907528"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS F<tspan
+   font-size="2.19403px"
+   x="173.09103"
+   y="35.907528"
+   
+   >-</tspan><tspan
+   font-size="2.19403px"
+   x="174.01094"
+   y="35.907528"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="168.91231"
+   y="38.65007"
+   
+   >10005</tspan></text>
+    <rect
+       x="135.7934"
+       y="10.259789"
+       width="17.510468"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="166.2525"
+       y="13.830078"
+       
+       transform="scale(0.84010005,1.1903344)">DATA 1</text>
+    <rect
+       x="135.7934"
+       y="19.726957"
+       width="17.510468"
+       height="9.4671526"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="166.61177"
+       y="20.412176"
+       
+       transform="scale(0.84010005,1.1903344)">IP <tspan
+   font-size="2.19403px"
+   x="170.6913"
+   y="20.412176"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="2.19403px"
+   x="170.65131"
+   y="23.291843"
+   
+   >192.0.2.88</tspan><tspan
+   font-size="3.15392px"
+   x="7.9119048"
+   y="83.216354"
+   
+   >Source 2</tspan><tspan
+   font-size="3.15392px"
+   x="9.0692492"
+   y="86.370277"
+   
+   >192.0.2.12</tspan></text>
+    <path
+       d="m 15.178529,87.797021 c 0,-0.453166 -0.259271,-0.820524 -0.579098,-0.820524 H 8.15439 c -0.3198304,0 -0.5791011,0.367358 -0.5791011,0.820524 v 7.173265 c 0,0.453171 0.2592707,0.820528 0.5791011,0.820528 h 6.445041 c 0.319827,0 0.579098,-0.367357 0.579098,-0.820528 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 13.84739,87.62941 v 0.930588 H 12.310614 L 11.492127,90.64815 10.656924,88.559998 H 9.1368541 V 87.62941 l -0.9855399,1.180256 0.9855399,1.180248 V 89.19552 h 1.0857639 l 0.935427,2.29242 -0.935427,2.315117 H 9.1368541 v -0.862498 l -0.9855399,1.180267 0.9855399,1.180258 v -0.885198 h 1.5200699 l 0.835203,-2.133538 0.818487,2.133538 h 1.536776 v 0.839789 l 0.985539,-1.134849 -0.985539,-1.180267 v 0.862498 h -1.069062 l -0.95212,-2.315117 0.935417,-2.29242 h 1.085765 v 0.771703 l 0.985539,-1.157557 z"
+       stroke="#000000"
+       stroke-width="0.239973"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 15.178529,91.383626 H 37.448042"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="17.367334"
+       y="110.4812"
+       width="17.510468"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="25.238726"
+       y="98.026085"
+       
+       transform="scale(0.84010005,1.1903344)">DATA 2</text>
+    <rect
+       x="17.367334"
+       y="119.94836"
+       width="17.510468"
+       height="9.4671688"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="25.598682"
+       y="104.60818"
+       
+       transform="scale(0.84010005,1.1903344)">IP <tspan
+   font-size="2.19403px"
+   x="29.678211"
+   y="104.60818"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="2.19403px"
+   x="29.638214"
+   y="107.48785"
+   
+   >192.0.2.89</tspan><tspan
+   font-size="3.15392px"
+   x="216.4343"
+   y="83.216354"
+   
+   >Destination 2</tspan><tspan
+   font-size="3.15392px"
+   x="220.61255"
+   y="86.370277"
+   
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 192.81761,87.797014 c 0,-0.453159 -0.25927,-0.820517 -0.5791,-0.820517 h -6.32983 c -0.31984,0 -0.57911,0.367358 -0.57911,0.820517 v 7.173228 c 0,0.453162 0.25927,0.820519 0.57911,0.820519 h 6.32983 c 0.31983,0 0.5791,-0.367357 0.5791,-0.820519 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 191.60167,87.62941 v 0.930588 h -1.53678 l -0.8185,2.088152 -0.8352,-2.088152 h -1.52007 V 87.62941 l -0.98555,1.180256 0.98555,1.180248 V 89.19552 h 1.08577 l 0.93542,2.29242 -0.93542,2.315117 h -1.08577 v -0.862498 l -0.98555,1.180267 0.98555,1.180258 v -0.885198 h 1.52007 l 0.8352,-2.133538 0.8185,2.133538 h 1.53678 v 0.839789 l 0.98554,-1.134849 -0.98554,-1.180267 v 0.862498 h -1.06906 l -0.95213,-2.315117 0.93542,-2.29242 h 1.08577 v 0.771703 l 0.98554,-1.157557 z"
+       stroke="#000000"
+       stroke-width="0.239973"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 163.09589,91.383626 22.27977,0.0095"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="165.16951"
+       y="110.4812"
+       width="17.510468"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="201.18015"
+       y="98.026085"
+       
+       transform="scale(0.84010005,1.1903344)">DATA 2</text>
+    <rect
+       x="165.16951"
+       y="119.94836"
+       width="17.510468"
+       height="9.4671688"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="201.53941"
+       y="104.60818"
+       
+       transform="scale(0.84010005,1.1903344)">IP <tspan
+   font-size="2.19403px"
+   x="205.61893"
+   y="104.60818"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="2.19403px"
+   x="205.57893"
+   y="107.48785"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="49.508259"
+       y="110.4812"
+       width="17.510468"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.19403px"
+       
+       x="62.335018"
+       y="96.243423"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS S<tspan
+   font-size="2.19403px"
+   x="70.374092"
+   y="96.243423"
+   
+   >-</tspan><tspan
+   font-size="2.19403px"
+   x="71.293983"
+   y="96.243423"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="67.414429"
+   y="98.985977"
+   
+   >103</tspan></text>
+    <rect
+       x="49.508259"
+       y="91.54686"
+       width="17.510468"
+       height="9.6303797"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="63.474957"
+       y="82.119339"
+       
+       transform="scale(0.84010005,1.1903344)">DATA 2</text>
+    <rect
+       x="49.508259"
+       y="101.01403"
+       width="17.510468"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="63.834915"
+       y="88.701447"
+       
+       transform="scale(0.84010005,1.1903344)">IP <tspan
+   font-size="2.19403px"
+   x="67.914444"
+   y="88.701447"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="2.19403px"
+   x="67.874458"
+   y="91.5811"
+   
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 44.900243,87.797014 c 0,-0.453159 -0.259269,-0.820517 -0.579094,-0.820517 h -6.329845 c -0.319831,0 -0.579101,0.367358 -0.579101,0.820517 v 7.173228 c 0,0.453162 0.25927,0.820519 0.579101,0.820519 h 6.329845 c 0.319825,0 0.579094,-0.367357 0.579094,-0.820519 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 43.552109,87.62941 v 0.930588 H 41.98884 l -0.832611,2.088152 -0.849603,-2.088152 h -1.54629 V 87.62941 l -1.002532,1.180256 1.002532,1.180248 V 89.19552 h 1.104485 l 0.951566,2.29242 -0.951566,2.315117 h -1.104485 v -0.862498 l -1.002532,1.180267 1.002532,1.180258 v -0.885198 h 1.54629 l 0.849603,-2.133538 0.832611,2.133538 h 1.563269 v 0.839789 l 1.002533,-1.134849 -1.002533,-1.180267 v 0.862498 h -1.087491 l -0.968547,-2.315117 0.951555,-2.29242 h 1.104483 v 0.771703 l 1.002533,-1.157557 z"
+       stroke="#000000"
+       stroke-width="0.239973"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 44.900243,91.449736 66.71529,70.164114"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="43.021767"
+       y="83.216354"
+       
+       transform="scale(0.84010005,1.1903344)">Ingress 2<tspan
+   font-size="3.15392px"
+   x="44.320827"
+   y="86.370277"
+   
+   >192.0.2.23</tspan></text>
+    <path
+       d="m 163.09589,87.797021 c 0,-0.453166 -0.25927,-0.820524 -0.57909,-0.820524 h -6.44504 c -0.31983,0 -0.5791,0.367358 -0.5791,0.820524 v 7.173265 c 0,0.453171 0.25927,0.820528 0.5791,0.820528 h 6.44504 c 0.31982,0 0.57909,-0.367357 0.57909,-0.820528 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 161.86296,87.62941 v 0.930588 h -1.56327 l -0.83261,2.088152 -0.84961,-2.088152 h -1.54628 V 87.62941 l -1.00253,1.180256 1.00253,1.180248 V 89.19552 h 1.10449 l 0.95156,2.29242 -0.95156,2.315117 h -1.10449 v -0.862498 l -1.00253,1.180267 1.00253,1.180258 v -0.885198 h 1.54628 l 0.84961,-2.133538 0.83261,2.133538 h 1.56327 v 0.839789 l 1.00253,-1.134849 -1.00253,-1.180267 v 0.862498 h -1.08749 l -0.96855,-2.315117 0.95155,-2.29242 h 1.10449 v 0.771703 l 1.00253,-1.157557 z"
+       stroke="#000000"
+       stroke-width="0.239973"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="184.03239"
+       y="83.216354"
+       
+       transform="scale(0.84010005,1.1903344)">Egress 2<tspan
+   font-size="3.15392px"
+   x="184.8707"
+   y="86.370277"
+   
+   >192.0.2.78</tspan></text>
+    <rect
+       x="49.508259"
+       y="119.94836"
+       width="17.510468"
+       height="9.4671688"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.19403px"
+       
+       x="62.395077"
+       y="104.19681"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS F<tspan
+   font-size="2.19403px"
+   x="70.314163"
+   y="104.19681"
+   
+   >-</tspan><tspan
+   font-size="2.19403px"
+   x="71.23407"
+   y="104.19681"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="66.135452"
+   y="106.93934"
+   
+   >10006</tspan></text>
+    <path
+       d="m 133.48938,70.164114 22.05398,21.267988"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="133.25899"
+       y="110.4812"
+       width="17.625668"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.19403px"
+       
+       x="162.11125"
+       y="96.243423"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS S<tspan
+   font-size="2.19403px"
+   x="170.15033"
+   y="96.243423"
+   
+   >-</tspan><tspan
+   font-size="2.19403px"
+   x="171.07024"
+   y="96.243423"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="167.19067"
+   y="98.985977"
+   
+   >105</tspan></text>
+    <rect
+       x="133.25899"
+       y="91.54686"
+       width="17.625668"
+       height="9.6303797"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="163.25217"
+       y="82.119339"
+       
+       transform="scale(0.84010005,1.1903344)">DATA 2</text>
+    <rect
+       x="133.25899"
+       y="101.01403"
+       width="17.625668"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="163.61145"
+       y="88.701447"
+       
+       transform="scale(0.84010005,1.1903344)">IP <tspan
+   font-size="2.19403px"
+   x="167.69096"
+   y="88.701447"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="2.19403px"
+   x="167.65099"
+   y="91.5811"
+   
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 35.900209,72.449294 c -0.198836,0 -0.360002,-0.913419 -0.360002,-2.040337 0,-1.126757 0.161166,-2.040343 0.360002,-2.040343 0.198836,0 0.360001,0.913586 0.360001,2.040343 0,1.126918 -0.161165,2.040337 -0.360001,2.040337 H 16.460134 c -0.198835,0 -0.360001,-0.913419 -0.360001,-2.040337 0,-1.126757 0.161166,-2.040343 0.360001,-2.040343 h 19.440075"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="27.208826"
+       y="55.928078"
+       
+       transform="scale(0.84010005,1.1903344)">App-1</text>
+    <path
+       d="m 36.015409,93.668813 c -0.198836,0 -0.360001,-0.913582 -0.360001,-2.040343 0,-1.126913 0.161165,-2.040335 0.360001,-2.040335 0.198836,0 0.360001,0.913422 0.360001,2.040335 0,1.126761 -0.161165,2.040343 -0.360001,2.040343 H 16.575335 c -0.198836,0 -0.360002,-0.913582 -0.360002,-2.040343 0,-1.126913 0.161166,-2.040335 0.360002,-2.040335 h 19.440074"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="26.924562"
+       y="81.845085"
+       
+       transform="scale(0.84010005,1.1903344)">App-2</text>
+    <path
+       d="m 183.93219,72.286063 c -0.19813,0 -0.35942,-0.913414 -0.35942,-2.040337 0,-1.126917 0.16129,-2.040337 0.35942,-2.040337 0.1993,0 0.36059,0.91342 0.36059,2.040337 0,1.126923 -0.16129,2.040337 -0.36059,2.040337 h -19.44006 c -0.19816,0 -0.35943,-0.913414 -0.35943,-2.040337 0,-1.126917 0.16127,-2.040337 0.35943,-2.040337 h 19.44006"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="203.29875"
+       y="55.928078"
+       
+       transform="scale(0.84010005,1.1903344)">App-1</text>
+    <path
+       d="m 184.09118,93.99527 c -0.23847,0 -0.43201,-1.09623 -0.43201,-2.448415 0,-1.352167 0.19354,-2.448402 0.43201,-2.448402 0.23846,0 0.432,1.096235 0.432,2.448402 0,1.352185 -0.19354,2.448415 -0.432,2.448415 H 164.6799 c -0.23846,0 -0.432,-1.09623 -0.432,-2.448415 0,-1.352167 0.19354,-2.448402 0.432,-2.448402 h 19.41128"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="203.52637"
+       y="81.845085"
+       
+       transform="scale(0.84010005,1.1903344)">App-2</text>
+    <path
+       d="m 64.858719,74.734469 c -0.429467,0 -0.777603,-1.973086 -0.777603,-4.40713 0,-2.434038 0.348136,-4.407128 0.777603,-4.407128 0.429468,0 0.777604,1.97309 0.777604,4.407128 0,2.434044 -0.348136,4.40713 -0.777604,4.40713 H 46.253848 c -0.429467,0 -0.777603,-1.973086 -0.777603,-4.40713 0,-2.434038 0.348136,-4.407128 0.777603,-4.407128 h 18.604871"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="63.192196"
+       y="54.556808"
+       
+       transform="scale(0.84010005,1.1903344)">DN<tspan
+   font-size="3.15392px"
+   x="67.231728"
+   y="54.556808"
+   
+   >-1</tspan></text>
+    <path
+       d="M 67.010894,76.151772 C 66.659303,76.498468 65.58068,75.164247 64.601822,73.171574 63.622964,71.1789 63.114354,69.282527 63.465946,68.93567 c 0.351592,-0.346698 1.430213,0.987524 2.409072,2.980198 0.978858,1.992674 1.487467,3.889212 1.135876,4.235904 L 48.621332,94.288094 C 48.269741,94.634785 47.191119,93.300571 46.212261,91.30789 45.233403,89.315214 44.724793,87.418682 45.076385,87.071984 L 63.465946,68.93567"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       transform="matrix(0.707112,-0.6427161,0.45360852,1.0019042,0,0)"
+       
+       x="16.253254"
+       y="100.33291"
+       >DN<tspan
+   font-size="3.15392px"
+   x="20.299747"
+   y="100.32204"
+   >-</tspan><tspan
+   font-size="3.15392px"
+   x="21.275955"
+   y="100.29661"
+   
+   >2</tspan></text>
+    <path
+       d="m 153.67826,74.571244 c -0.4297,0 -0.7776,-1.973087 -0.7776,-4.40713 0,-2.434044 0.3479,-4.40713 0.7776,-4.40713 0.4297,0 0.77761,1.973086 0.77761,4.40713 0,2.434043 -0.34791,4.40713 -0.77761,4.40713 h -18.60487 c -0.4297,0 -0.77761,-1.973087 -0.77761,-4.40713 0,-2.434044 0.34791,-4.40713 0.77761,-4.40713 h 18.60487"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="168.87573"
+       y="54.556808"
+       
+       transform="scale(0.84010005,1.1903344)">DN<tspan
+   font-size="3.15392px"
+   x="172.91528"
+   y="54.556808"
+   
+   >-1</tspan></text>
+    <path
+       d="m 152.54008,93.834817 c -0.35943,-0.330214 0.10483,-2.249281 1.0368,-4.28635 0.93312,-2.037235 1.9803,-3.420908 2.33972,-3.090702 0.35942,0.330208 -0.10483,2.24927 -1.03795,4.286505 -0.93198,2.037073 -1.97914,3.420753 -2.33857,3.090547 L 133.74052,76.56343 c -0.35943,-0.330207 0.10483,-2.249269 1.0368,-4.286343 0.93198,-2.037073 1.97915,-3.420748 2.33858,-3.09054 l 18.8007,17.271218"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       transform="matrix(0.70489533,0.64758608,-0.4570456,0.99876337,0,0)"
+       
+       x="178.26369"
+       y="-29.807323"
+       >DN<tspan
+   font-size="3.15392px"
+   x="182.30127"
+   y="-29.810368"
+   
+   >-</tspan><tspan
+   font-size="3.15392px"
+   x="183.27545"
+   y="-29.788305"
+   
+   >2</tspan></text>
+    <path
+       d="m 68.861934,33.92771 c 0,-2.253676 1.263634,-4.080676 2.822412,-4.080676 1.558777,0 2.82241,1.827 2.82241,4.080676 0,2.253676 -1.263633,4.080676 -2.82241,4.080676 -1.558778,0 -2.822412,-1.827 -2.822412,-4.080676 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.75933px"
+       
+       x="83.547615"
+       y="30.696703"
+       
+       transform="scale(0.84010005,1.1903344)">R</text>
+    <path
+       d="m 125.65575,33.92771 c 0,-2.253676 1.26375,-4.080676 2.82241,-4.080676 1.55867,0 2.82241,1.827 2.82241,4.080676 0,2.253676 -1.26374,4.080676 -2.82241,4.080676 -1.55866,0 -2.82241,-1.827 -2.82241,-4.080676 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.75933px"
+       
+       x="151.43454"
+       y="30.696703"
+       
+       transform="scale(0.84010005,1.1903344)">E</text>
+    <path
+       d="m 68.861934,115.2964 c 0,-2.20863 1.263634,-3.99906 2.822412,-3.99906 1.558777,0 2.82241,1.79043 2.82241,3.99906 0,2.20862 -1.263633,3.99905 -2.82241,3.99905 -1.558778,0 -2.822412,-1.79043 -2.822412,-3.99905 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.75933px"
+       
+       x="83.547615"
+       y="98.985977"
+       
+       transform="scale(0.84010005,1.1903344)">R</text>
+    <path
+       d="m 125.65575,115.2964 c 0,-2.20863 1.26375,-3.99906 2.82241,-3.99906 1.55867,0 2.82241,1.79043 2.82241,3.99906 0,2.20862 -1.26374,3.99905 -2.82241,3.99905 -1.55866,0 -2.82241,-1.79043 -2.82241,-3.99905 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.75933px"
+       
+       x="151.43454"
+       y="98.985977"
+       
+       transform="scale(0.84010005,1.1903344)">E</text>
+    <rect
+       x="76.580368"
+       y="29.194126"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.64552px"
+       
+       x="94.206909"
+       y="26.72002"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS<tspan
+   font-size="1.64552px"
+   x="93.726967"
+   y="28.639799"
+   
+   >S</tspan><tspan
+   font-size="1.64552px"
+   x="94.646858"
+   y="28.639799"
+   
+   >-</tspan><tspan
+   font-size="1.64552px"
+   x="95.326782"
+   y="28.639799"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="94.426086"
+   y="31.245213"
+   
+   >101</tspan></text>
+    <rect
+       x="85.335602"
+       y="29.194126"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.64552px"
+       
+       x="104.6372"
+       y="26.72002"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS<tspan
+   font-size="1.64552px"
+   x="104.15726"
+   y="28.639799"
+   
+   >S</tspan><tspan
+   font-size="1.64552px"
+   x="105.07716"
+   y="28.639799"
+   
+   >-</tspan><tspan
+   font-size="1.64552px"
+   x="105.75708"
+   y="28.639799"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="104.85638"
+   y="31.245213"
+   
+   >104</tspan></text>
+    <rect
+       x="76.580368"
+       y="19.726957"
+       width="8.7552338"
+       height="9.4671526"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.78265px"
+       
+       x="95.52758"
+       y="19.178034"
+       
+       transform="scale(0.84010005,1.1903344)">IP<tspan
+   font-size="1.78265px"
+   x="93.546997"
+   y="21.234938"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.78265px"
+   x="93.546997"
+   y="23.291843"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="85.335602"
+       y="19.726957"
+       width="8.7552338"
+       height="9.4671526"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.78265px"
+       
+       x="105.95787"
+       y="19.178034"
+       
+       transform="scale(0.84010005,1.1903344)">IP<tspan
+   font-size="1.78265px"
+   x="103.97729"
+   y="21.234938"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.78265px"
+   x="103.97729"
+   y="23.291843"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="76.580368"
+       y="10.259789"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91978px"
+       
+       x="93.706947"
+       y="12.184552"
+       
+       transform="scale(0.84010005,1.1903344)">DATA <tspan
+   font-size="1.91978px"
+   x="95.786682"
+   y="14.515712"
+   
+   >1</tspan></text>
+    <rect
+       x="85.335602"
+       y="10.259789"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91978px"
+       
+       x="104.13723"
+       y="12.184552"
+       
+       transform="scale(0.84010005,1.1903344)">DATA <tspan
+   font-size="1.91978px"
+   x="106.21698"
+   y="14.515712"
+   
+   >2</tspan></text>
+    <rect
+       x="76.465164"
+       y="110.4812"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.64552px"
+       
+       x="94.09803"
+       y="95.0093"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS<tspan
+   font-size="1.64552px"
+   x="93.618088"
+   y="96.929077"
+   
+   >S</tspan><tspan
+   font-size="1.64552px"
+   x="94.537987"
+   y="96.929077"
+   
+   >-</tspan><tspan
+   font-size="1.64552px"
+   x="95.217911"
+   y="96.929077"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="94.317207"
+   y="99.534492"
+   
+   >101</tspan></text>
+    <rect
+       x="85.220398"
+       y="110.4812"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.64552px"
+       
+       x="104.52833"
+       y="95.0093"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS<tspan
+   font-size="1.64552px"
+   x="104.04838"
+   y="96.929077"
+   
+   >S</tspan><tspan
+   font-size="1.64552px"
+   x="104.96828"
+   y="96.929077"
+   
+   >-</tspan><tspan
+   font-size="1.64552px"
+   x="105.6482"
+   y="96.929077"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="104.74751"
+   y="99.534492"
+   
+   >104</tspan></text>
+    <rect
+       x="76.465164"
+       y="101.01403"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.78265px"
+       
+       x="95.418694"
+       y="87.4673"
+       
+       transform="scale(0.84010005,1.1903344)">IP<tspan
+   font-size="1.78265px"
+   x="93.438126"
+   y="89.5242"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.78265px"
+   x="93.438126"
+   y="91.5811"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="85.220398"
+       y="101.01403"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.78265px"
+       
+       x="105.84899"
+       y="87.4673"
+       
+       transform="scale(0.84010005,1.1903344)">IP<tspan
+   font-size="1.78265px"
+   x="103.86842"
+   y="89.5242"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.78265px"
+   x="103.86842"
+   y="91.5811"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="76.465164"
+       y="91.54686"
+       width="8.7552338"
+       height="9.6303797"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91978px"
+       
+       x="93.598213"
+       y="80.610954"
+       
+       transform="scale(0.84010005,1.1903344)">DATA <tspan
+   font-size="1.91978px"
+   x="95.677948"
+   y="82.942108"
+   
+   >1</tspan></text>
+    <rect
+       x="85.220398"
+       y="91.54686"
+       width="8.7552338"
+       height="9.6303797"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91978px"
+       
+       x="104.0285"
+       y="80.610954"
+       
+       transform="scale(0.84010005,1.1903344)">DATA <tspan
+   font-size="1.91978px"
+   x="106.10826"
+   y="82.942108"
+   
+   >2</tspan></text>
+    <rect
+       x="106.18688"
+       y="29.194126"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.64552px"
+       
+       x="129.43938"
+       y="26.72002"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS<tspan
+   font-size="1.64552px"
+   x="128.95943"
+   y="28.639799"
+   
+   >S</tspan><tspan
+   font-size="1.64552px"
+   x="129.87932"
+   y="28.639799"
+   
+   >-</tspan><tspan
+   font-size="1.64552px"
+   x="130.55927"
+   y="28.639799"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="129.65855"
+   y="31.245213"
+   
+   >101</tspan></text>
+    <rect
+       x="114.94211"
+       y="29.194126"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.64552px"
+       
+       x="139.86926"
+       y="26.72002"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS<tspan
+   font-size="1.64552px"
+   x="139.38931"
+   y="28.639799"
+   
+   >S</tspan><tspan
+   font-size="1.64552px"
+   x="140.3092"
+   y="28.639799"
+   
+   >-</tspan><tspan
+   font-size="1.64552px"
+   x="140.98914"
+   y="28.639799"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="140.08844"
+   y="31.245213"
+   
+   >104</tspan></text>
+    <rect
+       x="106.18688"
+       y="19.726957"
+       width="8.7552338"
+       height="9.4671526"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.78265px"
+       
+       x="130.7599"
+       y="19.178034"
+       
+       transform="scale(0.84010005,1.1903344)">IP<tspan
+   font-size="1.78265px"
+   x="128.77933"
+   y="21.234938"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.78265px"
+   x="128.77933"
+   y="23.291843"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="114.94211"
+       y="19.726957"
+       width="8.7552338"
+       height="9.4671526"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.78265px"
+       
+       x="141.18979"
+       y="19.178034"
+       
+       transform="scale(0.84010005,1.1903344)">IP<tspan
+   font-size="1.78265px"
+   x="139.20921"
+   y="21.234938"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.78265px"
+   x="139.20921"
+   y="23.291843"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="106.18688"
+       y="10.259789"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91978px"
+       
+       x="128.93886"
+       y="12.184552"
+       
+       transform="scale(0.84010005,1.1903344)">DATA <tspan
+   font-size="1.91978px"
+   x="131.01862"
+   y="14.515712"
+   
+   >1</tspan></text>
+    <rect
+       x="114.94211"
+       y="10.259789"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91978px"
+       
+       x="139.36874"
+       y="12.184552"
+       
+       transform="scale(0.84010005,1.1903344)">DATA <tspan
+   font-size="1.91978px"
+   x="141.4485"
+   y="14.515712"
+   
+   >2</tspan></text>
+    <rect
+       x="106.18688"
+       y="110.4812"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.64552px"
+       
+       x="129.5052"
+       y="95.0093"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS<tspan
+   font-size="1.64552px"
+   x="129.02525"
+   y="96.929077"
+   
+   >S</tspan><tspan
+   font-size="1.64552px"
+   x="129.94514"
+   y="96.929077"
+   
+   >-</tspan><tspan
+   font-size="1.64552px"
+   x="130.62508"
+   y="96.929077"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="129.72438"
+   y="99.534492"
+   
+   >101</tspan></text>
+    <rect
+       x="114.94211"
+       y="110.4812"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.64552px"
+       
+       x="139.93645"
+       y="95.0093"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS<tspan
+   font-size="1.64552px"
+   x="139.4565"
+   y="96.929077"
+   
+   >S</tspan><tspan
+   font-size="1.64552px"
+   x="140.3764"
+   y="96.929077"
+   
+   >-</tspan><tspan
+   font-size="1.64552px"
+   x="141.05634"
+   y="96.929077"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="140.15564"
+   y="99.534492"
+   
+   >104</tspan></text>
+    <rect
+       x="106.18688"
+       y="101.01403"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.78265px"
+       
+       x="130.82573"
+       y="87.4673"
+       
+       transform="scale(0.84010005,1.1903344)">IP<tspan
+   font-size="1.78265px"
+   x="128.84514"
+   y="89.5242"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.78265px"
+   x="128.84514"
+   y="91.5811"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="114.94211"
+       y="101.01403"
+       width="8.7552338"
+       height="9.467185"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.78265px"
+       
+       x="141.25697"
+       y="87.4673"
+       
+       transform="scale(0.84010005,1.1903344)">IP<tspan
+   font-size="1.78265px"
+   x="139.2764"
+   y="89.5242"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.78265px"
+   x="139.2764"
+   y="91.5811"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="106.18688"
+       y="91.54686"
+       width="8.7552338"
+       height="9.6303797"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91978px"
+       
+       x="129.00606"
+       y="80.610954"
+       
+       transform="scale(0.84010005,1.1903344)">DATA <tspan
+   font-size="1.91978px"
+   x="131.0858"
+   y="82.942108"
+   
+   >1</tspan></text>
+    <rect
+       x="114.94211"
+       y="91.54686"
+       width="8.7552338"
+       height="9.6303797"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.91978px"
+       
+       x="139.43593"
+       y="80.610954"
+       
+       transform="scale(0.84010005,1.1903344)">DATA <tspan
+   font-size="1.91978px"
+   x="141.5157"
+   y="82.942108"
+   
+   >2</tspan></text>
+    <rect
+       x="133.25899"
+       y="119.94836"
+       width="17.625668"
+       height="9.4671688"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.19403px"
+       
+       x="162.1716"
+       y="104.19681"
+       
+       transform="scale(0.84010005,1.1903344)">MPLS F<tspan
+   font-size="2.19403px"
+   x="170.09068"
+   y="104.19681"
+   
+   >-</tspan><tspan
+   font-size="2.19403px"
+   x="171.01059"
+   y="104.19681"
+   
+   >label</tspan><tspan
+   font-size="2.19403px"
+   x="165.91196"
+   y="106.93934"
+   
+   >10011</tspan><tspan
+   font-size="4.52519px"
+   x="188.81236"
+   y="40.43272"
+   
+   >Note: S-label in this</tspan><tspan
+   font-size="4.52519px"
+   x="188.81236"
+   y="45.780682"
+   
+   >diagram includes d-CW.</tspan></text>
+    <path
+       d="m 73.268351,69.837657 c -0.429466,0 -0.777603,-1.973086 -0.777603,-4.407127 0,-2.434041 0.348137,-4.407131 0.777603,-4.407131 0.429468,0 0.777603,1.97309 0.777603,4.407131 0,2.434041 -0.348135,4.407127 -0.777603,4.407127 h -5.58722 c -0.429468,0 -0.777604,-1.973086 -0.777604,-4.407127 0,-2.434041 0.348136,-4.407131 0.777604,-4.407131 h 5.58722"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="81.261703"
+       y="54.419682"
+       
+       transform="scale(0.84010005,1.1903344)">DN<tspan
+   font-size="3.15392px"
+   x="85.301231"
+   y="54.419682"
+   
+   >-1</tspan></text>
+    <path
+       d="m 73.037951,79.304831 c -0.429467,0 -0.777604,-1.973093 -0.777604,-4.407131 0,-2.434043 0.348137,-4.40713 0.777604,-4.40713 0.429467,0 0.777603,1.973087 0.777603,4.40713 0,2.434038 -0.348136,4.407131 -0.777603,4.407131 H 67.56593 c -0.429468,0 -0.777603,-1.973093 -0.777603,-4.407131 0,-2.434043 0.348135,-4.40713 0.777603,-4.40713 h 5.472021"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="81.304489"
+       y="65.526978"
+       
+       transform="scale(0.84010005,1.1903344)">DN<tspan
+   font-size="3.15392px"
+   x="85.344032"
+   y="65.526978"
+   
+   >-2</tspan></text>
+    <path
+       d="m 123.72614,79.141599 c -0.87436,0 -1.58401,-4.019302 -1.58401,-8.977485 0,-4.958185 0.70965,-8.977487 1.58401,-8.977487 0.87438,0 1.58401,4.019302 1.58401,8.977487 0,4.958183 -0.70963,8.977485 -1.58401,8.977485 H 76.781965 c -0.874833,0 -1.584006,-4.019302 -1.584006,-8.977485 0,-4.958185 0.709173,-8.977487 1.584006,-8.977487 h 46.944175"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="112.54669"
+       y="60.179016"
+       
+       transform="scale(0.84010005,1.1903344)">DN<tspan
+   font-size="3.15392px"
+   x="116.58623"
+   y="60.179016"
+   
+   >-1 / DN</tspan><tspan
+   font-size="3.15392px"
+   x="125.90514"
+   y="60.179016"
+   
+   >-2</tspan></text>
+    <path
+       d="m 132.59658,70.000889 c -0.4297,0 -0.7776,-1.973093 -0.7776,-4.407133 0,-2.43404 0.3479,-4.407129 0.7776,-4.407129 0.4297,0 0.7776,1.973089 0.7776,4.407129 0,2.43404 -0.3479,4.407133 -0.7776,4.407133 h -5.47202 c -0.4297,0 -0.77761,-1.973093 -0.77761,-4.407133 0,-2.43404 0.34791,-4.407129 0.77761,-4.407129 h 5.47202"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="152.12567"
+       y="54.693935"
+       
+       transform="scale(0.84010005,1.1903344)">DN<tspan
+   font-size="3.15392px"
+   x="156.16521"
+   y="54.693935"
+   
+   >-1</tspan></text>
+    <path
+       d="m 132.48138,79.304831 c -0.4297,0 -0.7776,-1.973093 -0.7776,-4.407131 0,-2.434043 0.3479,-4.40713 0.7776,-4.40713 0.4297,0 0.7776,1.973087 0.7776,4.40713 0,2.434038 -0.3479,4.407131 -0.7776,4.407131 h -5.47202 c -0.4297,0 -0.77761,-1.973093 -0.77761,-4.407131 0,-2.434043 0.34791,-4.40713 0.77761,-4.40713 h 5.47202"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="151.99677"
+       y="65.526978"
+       
+       transform="scale(0.84010005,1.1903344)">DN<tspan
+   font-size="3.15392px"
+   x="156.03632"
+   y="65.526978"
+   
+   >-2</tspan></text>
+    <path
+       d="m 62.46831,59.715625 c 0,-0.404477 0.231438,-0.732563 0.51702,-0.732563 h 14.978822 c 0.285467,0 0.517019,0.328086 0.517019,0.732563 v 22.529248 c 0,0.404639 -0.231552,0.732563 -0.517019,0.732563 H 62.98533 c -0.285582,0 -0.51702,-0.327924 -0.51702,-0.732563 z"
+       stroke="#000000"
+       stroke-width="0.639925"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.55971, 1.91978"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 121.33573,59.752513 c 0,-0.424879 0.24307,-0.769451 0.5426,-0.769451 h 15.73408 c 0.29952,0 0.54259,0.344572 0.54259,0.769451 v 22.292243 c 0,0.42488 -0.24307,0.769455 -0.54259,0.769455 h -15.73408 c -0.29953,0 -0.5426,-0.344575 -0.5426,-0.769455 z"
+       stroke="#000000"
+       stroke-width="0.639925"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.55971, 1.91978"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="3.15392px"
+       
+       x="76.126984"
+       y="75.400124"
+       
+       transform="scale(0.84010005,1.1903344)">aggregation<tspan
+   font-size="3.15392px"
+   x="144.81544"
+   y="75.400124"
+   
+   >disaggregation</tspan></text>
+    <path
+       d="m 74.161155,66.41428 c 0,-0.453162 -0.259271,-0.820524 -0.579099,-0.820524 h -6.445041 c -0.31983,0 -0.579101,0.367362 -0.579101,0.820524 v 7.173259 c 0,0.453165 0.259271,0.820529 0.579101,0.820529 h 6.445041 c 0.319828,0 0.579099,-0.367364 0.579099,-0.820529 z"
+       stroke="#000000"
+       stroke-width="0.319963"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 72.830016,66.246666 v 0.930586 H 71.29324 l -0.818488,2.08815 -0.835202,-2.08815 h -1.520071 v -0.930586 l -0.98554,1.180255 0.98554,1.18025 v -0.794397 h 1.085764 l 0.935428,2.292417 -0.935428,2.315114 h -1.085764 v -0.862493 l -0.98554,1.180263 0.98554,1.180263 v -0.885196 h 1.520071 l 0.835202,-2.133541 0.818488,2.133541 h 1.536776 v 0.839785 l 0.985538,-1.134852 -0.985538,-1.180263 v 0.862493 h -1.069063 l -0.95212,-2.315114 0.935417,-2.292417 h 1.085766 v 0.771713 l 0.985538,-1.157566 z"
+       stroke="#000000"
+       stroke-width="0.239973"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+  </g>
+</svg>
+</artwork>
+</artset>
+        </figure>
+        <figure anchor="example-detnet-json-service-aggregation-c-2">
+          <name>Example C-2 DetNet JSON Relay Aggregation Service Sub-Layer</name>
+          <artwork name="" type="" align="left" alt=""><![CDATA[
+{
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "eth0",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth1",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth2",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth3",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth4",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      }
+    ]
+  },
+  "ietf-detnet:detnet": {
+    "traffic-profile": [
+      {
+        "profile-name": "pf-1",
+        "traffic-requirements": {
+          "min-bandwidth": "100000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 100000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "member-services": [
+          "ssl-1",
+          "ssl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-2",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 1,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "fsl-1",
+          "fsl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-3",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 2,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "afl-1",
+          "afl-2"
+        ]
+      }
+    ],
+    "service-sub-layer": {
+      "service-sub-layer-list": [
+        {
+          "name": "ssl-1",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "replication",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 100
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 101
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "afl-1",
+                    "afl-2"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "ssl-2",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "replication",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 103
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 104
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "afl-1",
+                    "afl-2"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "forwarding-sub-layer": {
+      "forwarding-sub-layer-list": [
+        {
+          "name": "fsl-1",
+          "traffic-profile": "pf-2",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth0",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10000
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-2",
+          "traffic-profile": "pf-2",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10006
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-2"
+              ]
+            }
+          }
+        },
+        {
+          "name": "afl-1",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1",
+                "ssl-2"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth2",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20000
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "afl-2",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1",
+                "ssl-2"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth3",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20001
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+]]></artwork>
+        </figure>
+        <figure anchor="example-detnet-json-service-disaggregation-c-2">
+          <name>Example C-2 DetNet JSON Relay Disaggregation Service Sub-Layer</name>
+          <artwork name="" type="" align="left" alt=""><![CDATA[
+{
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "eth0",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth1",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth2",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth3",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth4",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      }
+    ]
+  },
+  "ietf-detnet:detnet": {
+    "traffic-profile": [
+      {
+        "profile-name": "pf-1",
+        "traffic-requirements": {
+          "min-bandwidth": "100000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 100000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "member-services": [
+          "ssl-1",
+          "ssl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-2",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 1,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "fsl-1",
+          "fsl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-3",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 2,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "afl-1",
+          "afl-2"
+        ]
+      }
+    ],
+    "service-sub-layer": {
+      "service-sub-layer-list": [
+        {
+          "name": "ssl-1",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "elimination",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 101
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 102
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-1"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "ssl-2",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "elimination",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 104
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 105
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-2"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "forwarding-sub-layer": {
+      "forwarding-sub-layer-list": [
+        {
+          "name": "afl-1",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth0",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20002
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1",
+                "ssl-2"
+              ]
+            }
+          }
+        },
+        {
+          "name": "afl-2",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20003
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1",
+                "ssl-2"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-1",
+          "traffic-profile": "pf-2",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth2",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10005
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "fsl-2",
+          "traffic-profile": "pf-2",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-2"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth3",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10011
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+]]></artwork>
+        </figure>
+      </section>
+      <section numbered="true" toc="default">
+              <name>Example C-3 JSON Relay Service Sub-Layer Aggregation/Disaggregation</name>
+        <t>
+                This illustrates the Relay node 1 aggregating the 
+                service sub-layers of DetNet flows 1 and 2 into a service sub-layer of Aggregated DetNet flow 1.
+                It also illustrates the Relay node 2 disaggregating the aggregated 
+                DetNet flow 1 into the  DetNet flows 1 and 2 service sub-layers.
+                A diagram illustrating both aggregation and disaggregation is shown and then the 
+                corresponding JSON operational data follows.
+        </t>
+        <figure anchor="case-c3">
+                <name>Case C-3 Example JSON Service Aggregation/Disaggregation</name>
+          <artset>
+            <artwork align="left" type="ascii-art" name="" alt=""><![CDATA[
+        
+Please consult the PDF or HTML versions for the Case C-3 Diagram.
+
+]]></artwork>
+        <artwork type="svg">
+<svg
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="210mm"
+   height="120mm"
+   viewBox="0 10 210 120"
+   version="1.1"
+   >
+  <g
+     >
+    <path
+       d="m 129.44107,62.50501 c 0,-0.344621 -0.23934,-0.623988 -0.53456,-0.623988 h -5.94938 c -0.29523,0 -0.53457,0.279367 -0.53457,0.623988 v 5.455064 c 0,0.344611 0.23934,0.623977 0.53457,0.623977 h 5.94938 c 0.29522,0 0.53456,-0.279366 0.53456,-0.623977 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 128.30295,62.377541 v 0.707687 h -1.44305 l -0.76857,1.587983 -0.78427,-1.587983 h -1.42736 v -0.707687 l -0.92543,0.897554 0.92543,0.89755 v -0.604119 h 1.01954 l 0.87839,1.743323 -0.87839,1.760583 H 123.8797 V 66.41653 l -0.92543,0.897558 0.92543,0.897559 v -0.673172 h 1.42736 l 0.78427,-1.622498 0.76857,1.622498 h 1.44305 v 0.638638 l 0.92543,-0.863025 -0.92543,-0.897558 v 0.655902 h -1.00386 l -0.89406,-1.760583 0.87837,-1.743323 h 1.01955 v 0.586862 l 0.92543,-0.880293 z"
+       stroke="#000000"
+       stroke-width="0.20106"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 74.569081,62.505005 c 0,-0.344616 -0.239331,-0.623983 -0.53456,-0.623983 h -5.843053 c -0.295233,0 -0.534564,0.279367 -0.534564,0.623983 v 5.455069 c 0,0.344611 0.239331,0.623977 0.534564,0.623977 h 5.843053 c 0.295229,0 0.53456,-0.279366 0.53456,-0.623977 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 73.430967,62.377541 v 0.707687 h -1.443049 l -0.76857,1.587983 -0.784264,-1.587983 h -1.427363 v -0.707687 l -0.925434,0.897554 0.925434,0.89755 v -0.604119 h 1.019544 l 0.878377,1.743323 -0.878377,1.760583 H 69.007721 V 66.41653 l -0.925434,0.897558 0.925434,0.897559 v -0.673172 h 1.427363 l 0.784264,-1.622498 0.76857,1.622498 h 1.443049 v 0.638638 l 0.925431,-0.863025 -0.925431,-0.897558 v 0.655902 h -1.003861 l -0.894064,-1.760583 0.878378,-1.743323 h 1.019547 v 0.586862 l 0.925431,-0.880293 z"
+       stroke="#000000"
+       stroke-width="0.20106"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="112.2138"
+       y="26.87639"
+       width="8.188261"
+       height="7.199522"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.3787px"
+       
+       x="123.87114"
+       y="26.714422"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS<tspan
+   font-size="1.3787px"
+   x="123.46902"
+   y="28.322903"
+   
+   >S</tspan><tspan
+   font-size="1.3787px"
+   x="124.23975"
+   y="28.322903"
+   
+   >-</tspan><tspan
+   font-size="1.3787px"
+   x="124.80943"
+   y="28.322903"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="124.05479"
+   y="30.505838"
+   
+   >104</tspan><tspan
+   font-size="2.64251px"
+   x="13.114499"
+   y="65.662704"
+   
+   >Source 1</tspan><tspan
+   font-size="2.64251px"
+   x="14.085011"
+   y="68.305214"
+   
+   >192.0.2.1</tspan></text>
+    <path
+       d="m 20.016102,62.50501 c 0,-0.344621 -0.239343,-0.623988 -0.534553,-0.623988 h -5.949364 c -0.29525,0 -0.534593,0.279367 -0.534593,0.623988 v 5.455064 c 0,0.344611 0.239343,0.623977 0.534593,0.623977 h 5.949364 c 0.29521,0 0.534553,-0.279366 0.534553,-0.623977 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 18.681007,62.253412 v 0.722744 h -1.418613 l -0.755527,1.621771 -0.770961,-1.621771 h -1.403179 v -0.722744 l -0.909784,0.916649 0.909784,0.916649 v -0.616973 h 1.002265 l 0.863483,1.780419 -0.863483,1.798045 H 14.332727 V 66.37835 l -0.909784,0.916649 0.909784,0.916648 v -0.687491 h 1.403179 l 0.770961,-1.657023 0.755527,1.657023 h 1.418613 v 0.652239 l 0.909744,-0.881396 -0.909744,-0.916649 v 0.669851 h -0.986831 l -0.878917,-1.798045 0.863483,-1.780419 h 1.002265 v 0.599347 l 0.909744,-0.899023 z"
+       stroke="#000000"
+       stroke-width="0.20106"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="42.534492"
+       y="65.662704"
+       
+       transform="scale(0.92557641,1.0804078)">Ingress 1<tspan
+   font-size="2.64251px"
+   x="43.622887"
+   y="68.305214"
+   
+   >192.0.2.2</tspan></text>
+    <path
+       d="m 47.34577,62.50501 c 0,-0.344616 -0.239335,-0.623988 -0.534564,-0.623988 h -5.84303 c -0.295233,0 -0.534564,0.279372 -0.534564,0.623988 v 5.455049 c 0,0.344626 0.239331,0.623992 0.534564,0.623992 h 5.84303 c 0.295229,0 0.534564,-0.279366 0.534564,-0.623992 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 46.01066,62.253412 v 0.722744 h -1.41859 l -0.755555,1.621771 -0.770973,-1.621771 h -1.403167 v -0.722744 l -0.90976,0.916649 0.90976,0.916649 v -0.616973 h 1.002265 l 0.863487,1.780419 -0.863487,1.798045 H 41.662375 V 66.37835 l -0.90976,0.916649 0.90976,0.916648 v -0.687491 h 1.403167 l 0.770973,-1.657023 0.755555,1.657023 h 1.41859 v 0.652239 L 46.920407,67.294999 46.01066,66.37835 v 0.669851 h -0.986844 l -0.878908,-1.798045 0.863486,-1.780419 h 1.002266 v 0.599347 l 0.909747,-0.899023 z"
+       stroke="#000000"
+       stroke-width="0.20106"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="72.99366"
+       y="68.879669"
+       
+       transform="scale(0.92557641,1.0804078)">Relay 1<tspan
+   font-size="2.64251px"
+   x="73.161194"
+   y="71.522179"
+   
+   >192.0.2.3</tspan><tspan
+   font-size="2.64251px"
+   x="132.05373"
+   y="68.879669"
+   
+   >Relay 2</tspan><tspan
+   font-size="2.64251px"
+   x="132.22125"
+   y="71.522179"
+   
+   >192.0.2.6</tspan><tspan
+   font-size="2.64251px"
+   x="161.07043"
+   y="65.662704"
+   
+   >Egress 1</tspan><tspan
+   font-size="2.64251px"
+   x="161.77277"
+   y="68.305214"
+   
+   >192.0.2.77</tspan></text>
+    <path
+       d="m 156.66438,62.505005 c 0,-0.344616 -0.23934,-0.623983 -0.53457,-0.623983 h -5.84305 c -0.29523,0 -0.53457,0.279367 -0.53457,0.623983 v 5.455069 c 0,0.344611 0.23934,0.623977 0.53457,0.623977 h 5.84305 c 0.29523,0 0.53457,-0.279366 0.53457,-0.623977 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 155.32926,62.253412 v 0.722744 h -1.41859 l -0.75555,1.621771 -0.77098,-1.621771 h -1.40317 v -0.722744 l -0.90975,0.916649 0.90975,0.916649 v -0.616973 h 1.00227 l 0.86348,1.780419 -0.86348,1.798045 h -1.00227 V 66.37835 l -0.90975,0.916649 0.90975,0.916648 v -0.687491 h 1.40317 l 0.77098,-1.657023 0.75555,1.657023 h 1.41859 v 0.652239 l 0.90975,-0.881396 -0.90975,-0.916649 v 0.669851 h -0.98685 l -0.8789,-1.798045 0.86348,-1.780419 h 1.00227 v 0.599347 l 0.90975,-0.899023 z"
+       stroke="#000000"
+       stroke-width="0.20106"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="101.72691"
+       y="80.713516"
+       
+       transform="scale(0.92557641,1.0804078)">Transit 2<tspan
+   font-size="2.64251px"
+   x="102.69737"
+   y="83.356026"
+   
+   >192.0.2.5</tspan></text>
+    <path
+       d="m 102.00507,78.64189 c 0,-0.344616 -0.23933,-0.623982 -0.53456,-0.623982 h -5.84305 c -0.295234,0 -0.534565,0.279366 -0.534565,0.623982 v 5.455069 c 0,0.344612 0.239331,0.623978 0.534565,0.623978 h 5.84305 c 0.29523,0 0.53456,-0.279366 0.53456,-0.623978 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 100.66996,78.514426 v 0.707689 h -1.41859 l -0.755555,1.587982 -0.770973,-1.587982 h -1.403168 v -0.707689 l -0.909759,0.897555 0.909759,0.897549 v -0.604118 h 1.002266 l 0.863486,1.743323 -0.863486,1.760584 h -1.002266 v -0.655904 l -0.909759,0.89756 0.909759,0.897558 V 83.67536 h 1.403168 l 0.770973,-1.622498 0.755555,1.622498 h 1.41859 v 0.638638 l 0.90975,-0.863023 -0.90975,-0.89756 v 0.655904 h -0.986845 l -0.878908,-1.760584 0.863487,-1.743323 h 1.002266 v 0.586863 l 0.90975,-0.880294 z"
+       stroke="#000000"
+       stroke-width="0.20106"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="101.72691"
+       y="50.611893"
+       
+       transform="scale(0.92557641,1.0804078)">Transit 1<tspan
+   font-size="2.64251px"
+   x="102.69737"
+   y="53.254406"
+   
+   >192.0.2.4</tspan></text>
+    <path
+       d="m 102.00507,46.243985 c 0,-0.344616 -0.23933,-0.623982 -0.53456,-0.623982 h -5.84305 c -0.295234,0 -0.534565,0.279366 -0.534565,0.623982 v 5.45507 c 0,0.34461 0.239331,0.623977 0.534565,0.623977 h 5.84305 c 0.29523,0 0.53456,-0.279367 0.53456,-0.623977 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 100.66996,46.116521 v 0.707688 h -1.41859 l -0.755555,1.587982 -0.770973,-1.587982 h -1.403168 v -0.707688 l -0.909759,0.897559 0.909759,0.897559 v -0.604128 h 1.002266 l 0.863486,1.743328 -0.863486,1.760598 h -1.002266 v -0.655904 l -0.909759,0.897545 0.909759,0.897559 v -0.673168 h 1.403168 l 0.770973,-1.622502 0.755555,1.622502 h 1.41859 v 0.638648 l 0.90975,-0.863039 -0.90975,-0.897545 v 0.655904 h -0.986845 l -0.878908,-1.760598 0.863487,-1.743328 h 1.002266 v 0.586858 l 0.90975,-0.880289 z"
+       stroke="#000000"
+       stroke-width="0.20106"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="187.80952"
+       y="65.662704"
+       
+       transform="scale(0.92557641,1.0804078)">Destination 1<tspan
+   font-size="2.64251px"
+   x="191.31065"
+   y="68.305214"
+   
+   >192.0.2.88</tspan></text>
+    <path
+       d="m 183.99402,62.505005 c 0,-0.344616 -0.23933,-0.623983 -0.53456,-0.623983 h -5.84305 c -0.29524,0 -0.53457,0.279367 -0.53457,0.623983 v 5.455069 c 0,0.344611 0.23933,0.623977 0.53457,0.623977 h 5.84305 c 0.29523,0 0.53456,-0.279366 0.53456,-0.623977 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 182.74957,62.253412 v 0.722744 h -1.44305 l -0.76857,1.621771 -0.78426,-1.621771 h -1.42737 v -0.722744 l -0.92544,0.916649 0.92544,0.916649 v -0.616973 h 1.01955 l 0.87837,1.780419 -0.87837,1.798045 h -1.01955 V 66.37835 l -0.92544,0.916649 0.92544,0.916648 v -0.687491 h 1.42737 l 0.78426,-1.657023 0.76857,1.657023 h 1.44305 v 0.652239 l 0.92543,-0.881396 -0.92543,-0.916649 v 0.669851 h -1.00387 l -0.89406,-1.798045 0.87838,-1.780419 h 1.01955 v 0.599347 l 0.92543,-0.899023 z"
+       stroke="#000000"
+       stroke-width="0.20106"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 20.016102,65.232529 h 20.40155"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 47.34577,65.232529 H 67.747303"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 74.675422,65.188833 95.076951,48.97151"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 102.00507,48.97151 122.4066,65.188833"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 129.33472,65.232529 h 20.40153"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 156.66438,65.232529 H 177.0659"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 102.00507,81.41969 122.4066,65.232529"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 74.675422,65.232529 95.076951,81.419812"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="22.142925"
+       y="12.477315"
+       width="16.163839"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="27.707268"
+       y="15.914594"
+       
+       transform="scale(0.92557641,1.0804078)">DATA 1</text>
+    <rect
+       x="76.802231"
+       y="41.275452"
+       width="16.163839"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="85.863373"
+       y="41.075882"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS F<tspan
+   font-size="1.83826px"
+   x="92.49836"
+   y="41.075882"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="93.269089"
+   y="41.075882"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="88.997223"
+   y="43.373711"
+   
+   >20000</tspan></text>
+    <rect
+       x="76.908569"
+       y="109.54691"
+       width="16.163839"
+       height="7.1995339"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="85.99939"
+       y="104.26631"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS F<tspan
+   font-size="1.83826px"
+   x="92.634399"
+   y="104.26631"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="93.405128"
+   y="104.26631"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="89.133263"
+   y="106.56416"
+   
+   >20001</tspan></text>
+    <rect
+       x="104.13187"
+       y="41.275452"
+       width="16.270182"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="115.47947"
+       y="41.075882"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS F<tspan
+   font-size="1.83826px"
+   x="122.11445"
+   y="41.075882"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="122.88519"
+   y="41.075882"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="118.61332"
+   y="43.373711"
+   
+   >20002</tspan></text>
+    <rect
+       x="104.23822"
+       y="109.54691"
+       width="16.270182"
+       height="7.1995339"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="115.59436"
+       y="104.26631"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS F<tspan
+   font-size="1.83826px"
+   x="122.22934"
+   y="104.26631"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="123.00005"
+   y="104.26631"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="118.7282"
+   y="106.56416"
+   
+   >20003</tspan></text>
+    <rect
+       x="158.57849"
+       y="12.477315"
+       width="16.163839"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="175.16109"
+       y="15.914594"
+       
+       transform="scale(0.92557641,1.0804078)">DATA 1</text>
+    <rect
+       x="22.142925"
+       y="19.800978"
+       width="16.163839"
+       height="7.199522"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="28.008827"
+       y="21.544294"
+       
+       transform="scale(0.92557641,1.0804078)">IP <tspan
+   font-size="1.83826px"
+   x="31.426823"
+   y="21.544294"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.83826px"
+   x="31.393349"
+   y="23.957018"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="158.57849"
+       y="19.800978"
+       width="16.163839"
+       height="7.199522"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="175.46213"
+       y="21.544294"
+       
+       transform="scale(0.92557641,1.0804078)">IP <tspan
+   font-size="1.83826px"
+   x="178.88014"
+   y="21.544294"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.83826px"
+   x="178.84662"
+   y="23.957018"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="49.472607"
+       y="27.000523"
+       width="16.163839"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="56.311371"
+       y="27.863342"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS S<tspan
+   font-size="1.83826px"
+   x="63.046909"
+   y="27.863342"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="63.817638"
+   y="27.863342"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="60.567173"
+   y="30.161171"
+   
+   >100</tspan></text>
+    <rect
+       x="49.472607"
+       y="34.20005"
+       width="16.163839"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="56.361595"
+       y="34.641941"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS F<tspan
+   font-size="1.83826px"
+   x="62.996578"
+   y="34.641941"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="63.76733"
+   y="34.641941"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="59.495441"
+   y="36.939781"
+   
+   >10000</tspan></text>
+    <rect
+       x="49.472607"
+       y="12.477315"
+       width="16.163839"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="57.266354"
+       y="15.914594"
+       
+       transform="scale(0.92557641,1.0804078)">DATA 1</text>
+    <rect
+       x="49.472607"
+       y="19.800978"
+       width="16.163839"
+       height="7.199522"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="57.567932"
+       y="21.544294"
+       
+       transform="scale(0.92557641,1.0804078)">IP <tspan
+   font-size="1.83826px"
+   x="60.985985"
+   y="21.544294"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.83826px"
+   x="60.952488"
+   y="23.957018"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="129.12206"
+       y="26.87639"
+       width="16.270182"
+       height="7.199522"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="142.43649"
+       y="27.748436"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS S<tspan
+   font-size="1.83826px"
+   x="149.17201"
+   y="27.748436"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="149.94275"
+   y="27.748436"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="146.69226"
+   y="30.046278"
+   
+   >102</tspan></text>
+    <rect
+       x="129.12206"
+       y="33.951786"
+       width="16.270182"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="142.4859"
+       y="34.412163"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS F<tspan
+   font-size="1.83826px"
+   x="149.12091"
+   y="34.412163"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="149.89163"
+   y="34.412163"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="145.61977"
+   y="36.709995"
+   
+   >10005</tspan></text>
+    <rect
+       x="129.12206"
+       y="12.477315"
+       width="16.270182"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="143.39124"
+       y="15.914594"
+       
+       transform="scale(0.92557641,1.0804078)">DATA 1</text>
+    <rect
+       x="129.12206"
+       y="19.676861"
+       width="16.270182"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="143.69226"
+       y="21.429401"
+       
+       transform="scale(0.92557641,1.0804078)">IP <tspan
+   font-size="1.83826px"
+   x="147.11031"
+   y="21.429401"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.83826px"
+   x="147.07678"
+   y="23.842125"
+   
+   >192.0.2.88</tspan><tspan
+   font-size="2.64251px"
+   x="13.231592"
+   y="80.713516"
+   
+   >Source 2</tspan><tspan
+   font-size="2.64251px"
+   x="14.201256"
+   y="83.356026"
+   
+   >192.0.2.12</tspan></text>
+    <path
+       d="m 20.122449,78.641895 c 0,-0.344621 -0.239342,-0.623987 -0.534551,-0.623987 h -5.949406 c -0.29525,0 -0.534552,0.279366 -0.534552,0.623987 v 5.455078 c 0,0.344622 0.239302,0.623988 0.534552,0.623988 h 5.949406 c 0.295209,0 0.534551,-0.279366 0.534551,-0.623988 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 18.787355,78.514426 v 0.707689 h -1.418613 l -0.755527,1.587982 -0.770961,-1.587982 h -1.40318 v -0.707689 l -0.909783,0.897555 0.909783,0.897549 v -0.604118 h 1.002266 l 0.863482,1.743323 -0.863482,1.760584 h -1.002266 v -0.655904 l -0.909783,0.89756 0.909783,0.897558 V 83.67536 h 1.40318 l 0.770961,-1.622498 0.755527,1.622498 h 1.418613 v 0.638638 l 0.909744,-0.863023 -0.909744,-0.89756 v 0.655904 h -0.986832 l -0.878916,-1.760584 0.863483,-1.743323 h 1.002265 v 0.586863 l 0.909744,-0.880294 z"
+       stroke="#000000"
+       stroke-width="0.20106"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 20.122449,81.369416 H 40.523992"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="22.142925"
+       y="102.34737"
+       width="16.163839"
+       height="7.1995096"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="27.707958"
+       y="99.096191"
+       
+       transform="scale(0.92557641,1.0804078)">DATA 2</text>
+    <rect
+       x="22.142925"
+       y="109.54691"
+       width="16.163839"
+       height="7.1995339"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="28.009516"
+       y="104.611"
+       
+       transform="scale(0.92557641,1.0804078)">IP <tspan
+   font-size="1.83826px"
+   x="31.427538"
+   y="104.611"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.83826px"
+   x="31.394037"
+   y="107.02374"
+   
+   >192.0.2.89</tspan><tspan
+   font-size="2.64251px"
+   x="187.94106"
+   y="80.713516"
+   
+   >Destination 2</tspan><tspan
+   font-size="2.64251px"
+   x="191.44296"
+   y="83.356026"
+   
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 184.10037,78.64189 c 0,-0.344616 -0.23934,-0.623982 -0.53457,-0.623982 h -5.84305 c -0.29523,0 -0.53457,0.279366 -0.53457,0.623982 v 5.455069 c 0,0.344612 0.23934,0.623978 0.53457,0.623978 h 5.84305 c 0.29523,0 0.53457,-0.279366 0.53457,-0.623978 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 182.85591,78.514426 v 0.707689 h -1.44305 l -0.76857,1.587982 -0.78426,-1.587982 h -1.42736 v -0.707689 l -0.92544,0.897555 0.92544,0.897549 v -0.604118 h 1.01954 l 0.87838,1.743323 -0.87838,1.760584 h -1.01954 v -0.655904 l -0.92544,0.89756 0.92544,0.897558 V 83.67536 h 1.42736 l 0.78426,-1.622498 0.76857,1.622498 h 1.44305 v 0.638638 l 0.92543,-0.863023 -0.92543,-0.89756 v 0.655904 h -1.00386 l -0.89406,-1.760584 0.87837,-1.743323 h 1.01955 v 0.586863 l 0.92543,-0.880294 z"
+       stroke="#000000"
+       stroke-width="0.20106"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 156.66438,81.369416 20.56635,0.0072"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="158.57849"
+       y="102.34737"
+       width="16.163839"
+       height="7.1995096"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="175.16109"
+       y="99.096191"
+       
+       transform="scale(0.92557641,1.0804078)">DATA 2</text>
+    <rect
+       x="158.57849"
+       y="109.54691"
+       width="16.163839"
+       height="7.1995339"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="175.46213"
+       y="104.611"
+       
+       transform="scale(0.92557641,1.0804078)">IP <tspan
+   font-size="1.83826px"
+   x="178.88014"
+   y="104.611"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.83826px"
+   x="178.84662"
+   y="107.02374"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="76.802231"
+       y="34.07592"
+       width="16.163839"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="85.695847"
+       y="34.412163"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS A<tspan
+   font-size="1.83826px"
+   x="92.665939"
+   y="34.412163"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="93.436668"
+   y="34.412163"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="89.533417"
+   y="36.709995"
+   
+   >1000</tspan></text>
+    <rect
+       x="49.472607"
+       y="102.34737"
+       width="16.163839"
+       height="7.1995096"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="56.358143"
+       y="97.717499"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS S<tspan
+   font-size="1.83826px"
+   x="63.093662"
+   y="97.717499"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="63.864391"
+   y="97.717499"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="60.613926"
+   y="100.01533"
+   
+   >103</tspan></text>
+    <rect
+       x="49.472607"
+       y="88.072433"
+       width="16.163839"
+       height="7.3236766"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="57.313129"
+       y="85.883644"
+       
+       transform="scale(0.92557641,1.0804078)">DATA 2</text>
+    <rect
+       x="49.472607"
+       y="95.271973"
+       width="16.163839"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="57.614712"
+       y="91.398445"
+       
+       transform="scale(0.92557641,1.0804078)">IP <tspan
+   font-size="1.83826px"
+   x="61.032734"
+   y="91.398445"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.83826px"
+   x="60.999233"
+   y="93.81118"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="76.908569"
+       y="102.34737"
+       width="16.163839"
+       height="7.1995096"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="85.831886"
+       y="97.717499"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS A<tspan
+   font-size="1.83826px"
+   x="92.801979"
+   y="97.717499"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="93.572716"
+   y="97.717499"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="89.669456"
+   y="100.01533"
+   
+   >1000</tspan></text>
+    <rect
+       x="104.23822"
+       y="102.34737"
+       width="16.270182"
+       height="7.1995096"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="115.42661"
+       y="97.717499"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS A<tspan
+   font-size="1.83826px"
+   x="122.39669"
+   y="97.717499"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="123.16743"
+   y="97.717499"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="119.26418"
+   y="100.01533"
+   
+   >1000</tspan></text>
+    <rect
+       x="104.13187"
+       y="34.07592"
+       width="16.270182"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="115.31286"
+       y="34.412163"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS A<tspan
+   font-size="1.83826px"
+   x="122.28296"
+   y="34.412163"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="123.05369"
+   y="34.412163"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="119.15044"
+   y="36.709995"
+   
+   >1000</tspan></text>
+    <path
+       d="m 47.452114,78.64189 c 0,-0.344616 -0.239331,-0.623982 -0.534561,-0.623982 H 41.07452 c -0.295234,0 -0.534564,0.279366 -0.534564,0.623982 v 5.455047 c 0,0.34462 0.23933,0.623972 0.534564,0.623972 h 5.843033 c 0.29523,0 0.534561,-0.279352 0.534561,-0.623972 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 46.116999,78.514426 v 0.707689 h -1.418588 l -0.755556,1.587982 -0.770973,-1.587982 h -1.403167 v -0.707689 l -0.90976,0.897555 0.90976,0.897549 v -0.604118 h 1.002265 l 0.863487,1.743323 -0.863487,1.760584 h -1.002265 v -0.655904 l -0.90976,0.89756 0.90976,0.897558 V 83.67536 h 1.403167 l 0.770973,-1.622498 0.755556,1.622498 h 1.418588 v 0.638638 l 0.909748,-0.863023 -0.909748,-0.89756 v 0.655904 h -0.986843 l -0.878909,-1.760584 0.863487,-1.743323 h 1.002265 v 0.586863 l 0.909748,-0.880294 z"
+       stroke="#000000"
+       stroke-width="0.20106"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 47.452114,81.419812 67.744855,65.232529"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="42.64835"
+       y="80.713516"
+       
+       transform="scale(0.92557641,1.0804078)">Ingress 2<tspan
+   font-size="2.64251px"
+   x="43.736748"
+   y="83.356026"
+   
+   >192.0.2.23</tspan></text>
+    <path
+       d="m 156.66438,78.641895 c 0,-0.344621 -0.23934,-0.623987 -0.53457,-0.623987 h -5.94939 c -0.29524,0 -0.53457,0.279366 -0.53457,0.623987 v 5.455078 c 0,0.344622 0.23933,0.623988 0.53457,0.623988 h 5.94939 c 0.29523,0 0.53457,-0.279366 0.53457,-0.623988 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 155.32926,78.514426 v 0.707689 h -1.41859 l -0.75555,1.587982 -0.77098,-1.587982 h -1.40317 v -0.707689 l -0.90975,0.897555 0.90975,0.897549 v -0.604118 h 1.00227 l 0.86348,1.743323 -0.86348,1.760584 h -1.00227 v -0.655904 l -0.90975,0.89756 0.90975,0.897558 V 83.67536 h 1.40317 l 0.77098,-1.622498 0.75555,1.622498 h 1.41859 v 0.638638 l 0.90975,-0.863023 -0.90975,-0.89756 v 0.655904 h -0.98685 l -0.8789,-1.760584 0.86348,-1.743323 h 1.00227 v 0.586863 l 0.90975,-0.880294 z"
+       stroke="#000000"
+       stroke-width="0.20106"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="160.7939"
+       y="80.713516"
+       
+       transform="scale(0.92557641,1.0804078)">Egress 2<tspan
+   font-size="2.64251px"
+   x="161.49625"
+   y="83.356026"
+   
+   >192.0.2.78</tspan></text>
+    <rect
+       x="49.472607"
+       y="109.54691"
+       width="16.163839"
+       height="7.1995339"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="56.408344"
+       y="104.26631"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS F<tspan
+   font-size="1.83826px"
+   x="63.043331"
+   y="104.26631"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="63.81406"
+   y="104.26631"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="59.542217"
+   y="106.56416"
+   
+   >10006</tspan></text>
+    <path
+       d="m 129.33472,65.232529 20.35793,16.173752"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="129.12206"
+       y="102.34737"
+       width="16.163839"
+       height="7.1995096"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="142.39743"
+       y="97.6026"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS S<tspan
+   font-size="1.83826px"
+   x="149.13295"
+   y="97.6026"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="149.90369"
+   y="97.6026"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="146.6532"
+   y="99.900436"
+   
+   >105</tspan></text>
+    <rect
+       x="129.12206"
+       y="109.54691"
+       width="16.163839"
+       height="7.1995339"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.83826px"
+       
+       x="142.448"
+       y="104.26631"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS F<tspan
+   font-size="1.83826px"
+   x="149.08298"
+   y="104.26631"
+   
+   >-</tspan><tspan
+   font-size="1.83826px"
+   x="149.8537"
+   y="104.26631"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="145.58183"
+   y="106.56416"
+   
+   >10011</tspan></text>
+    <rect
+       x="129.12206"
+       y="87.948296"
+       width="16.163839"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="143.35216"
+       y="85.768753"
+       
+       transform="scale(0.92557641,1.0804078)">DATA 2</text>
+    <rect
+       x="129.12206"
+       y="95.147835"
+       width="16.163839"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="143.65434"
+       y="91.283554"
+       
+       transform="scale(0.92557641,1.0804078)">IP <tspan
+   font-size="1.83826px"
+   x="147.07239"
+   y="91.283554"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.83826px"
+   x="147.03886"
+   y="93.696281"
+   
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 39.463243,66.970345 c -0.183548,0 -0.332319,-0.694753 -0.332319,-1.551622 0,-0.856992 0.148771,-1.551624 0.332319,-1.551624 0.183544,0 0.332315,0.694632 0.332315,1.551624 0,0.856869 -0.148771,1.551622 -0.332315,1.551622 H 21.411846 c -0.183556,0 -0.332307,-0.694753 -0.332307,-1.551622 0,-0.856992 0.148751,-1.551624 0.332307,-1.551624 h 18.051397"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="29.399529"
+       y="58.309635"
+       
+       transform="scale(0.92557641,1.0804078)">App-1</text>
+    <path
+       d="m 39.569583,83.107235 c -0.183544,0 -0.332315,-0.694758 -0.332315,-1.551622 0,-0.856996 0.148771,-1.551628 0.332315,-1.551628 0.183544,0 0.332314,0.694632 0.332314,1.551628 0,0.856864 -0.14877,1.551622 -0.332314,1.551622 h -18.05139 c -0.183556,0 -0.332306,-0.694758 -0.332306,-1.551622 0,-0.856996 0.14875,-1.551628 0.332306,-1.551628 h 18.05139"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="29.161312"
+       y="79.679497"
+       
+       transform="scale(0.92557641,1.0804078)">App-2</text>
+    <path
+       d="m 176.11096,66.846217 c -0.1829,0 -0.33178,-0.694632 -0.33178,-1.551623 0,-0.856991 0.14888,-1.551623 0.33178,-1.551623 0.18397,0 0.33285,0.694632 0.33285,1.551623 0,0.856991 -0.14888,1.551623 -0.33285,1.551623 h -18.05139 c -0.18291,0 -0.33179,-0.694632 -0.33179,-1.551623 0,-0.856991 0.14888,-1.551623 0.33179,-1.551623 h 18.05139"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="176.93617"
+       y="58.309635"
+       
+       transform="scale(0.92557641,1.0804078)">App-1</text>
+    <path
+       d="m 176.15137,83.355493 c -0.22013,0 -0.39878,-0.833656 -0.39878,-1.861949 0,-1.028289 0.17865,-1.861949 0.39878,-1.861949 0.22013,0 0.39878,0.83366 0.39878,1.861949 0,1.028293 -0.17865,1.861949 -0.39878,1.861949 h -17.81213 c -0.22012,0 -0.39877,-0.833656 -0.39877,-1.861949 0,-1.028289 0.17865,-1.861949 0.39877,-1.861949 h 17.81213"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="177.12691"
+       y="79.679497"
+       
+       transform="scale(0.92557641,1.0804078)">App-2</text>
+    <path
+       d="m 65.982039,68.708165 c -0.396436,0 -0.717799,-1.500481 -0.717799,-3.351507 0,-1.851027 0.321363,-3.351507 0.717799,-3.351507 0.396441,0 0.717804,1.50048 0.717804,3.351507 0,1.851026 -0.321363,3.351507 -0.717804,3.351507 H 48.807963 c -0.396441,0 -0.717803,-1.500481 -0.717803,-3.351507 0,-1.851027 0.321362,-3.351507 0.717803,-3.351507 h 17.174076"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="59.548103"
+       y="56.701153"
+       
+       transform="scale(0.92557641,1.0804078)">DN-1</text>
+    <path
+       d="m 68.015283,69.944251 c -0.327532,0.258564 -1.311506,-0.771592 -2.197645,-2.300869 -0.886143,-1.529282 -1.339049,-2.978747 -1.011517,-3.237311 0.327531,-0.258564 1.311505,0.771469 2.197644,2.300873 0.886139,1.529283 1.339046,2.97862 1.011518,3.237307 L 50.883633,83.470439 C 50.556102,83.729003 49.572128,82.69897 48.685989,81.169566 47.79985,79.640284 47.346944,78.190946 47.674472,77.93226 L 64.806121,64.406071"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       transform="matrix(0.77464881,-0.59130697,0.50656776,0.90423291,0,0)"
+       
+       x="8.9874916"
+       y="97.099846"
+       >DN<tspan
+   font-size="2.64251px"
+   x="12.3643"
+   y="97.111618"
+   
+   >-</tspan><tspan
+   font-size="2.64251px"
+   x="13.179154"
+   y="97.095398"
+   
+   >2</tspan></text>
+    <path
+       d="m 147.97099,68.584038 c -0.39665,0 -0.7178,-1.500487 -0.7178,-3.351509 0,-1.851026 0.32115,-3.351507 0.7178,-3.351507 0.39665,0 0.7178,1.500481 0.7178,3.351507 0,1.851022 -0.32115,3.351509 -0.7178,3.351509 h -17.17408 c -0.39665,0 -0.7178,-1.500487 -0.7178,-3.351509 0,-1.851026 0.32115,-3.351507 0.7178,-3.351507 h 17.17408"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="148.09488"
+       y="56.701153"
+       
+       transform="scale(0.92557641,1.0804078)">DN<tspan
+   font-size="2.64251px"
+   x="151.47943"
+   y="56.701153"
+   
+   >-1</tspan></text>
+    <path
+       d="m 146.92034,83.233475 c -0.33178,-0.251114 0.0968,-1.71051 0.95707,-3.259651 0.86136,-1.549264 1.82801,-2.601516 2.15978,-2.350402 0.33179,0.251118 -0.0968,1.71051 -0.95813,3.259778 -0.8603,1.549141 -1.82693,2.601389 -2.15872,2.350275 l -17.3538,-13.134433 c -0.33178,-0.251113 0.0968,-1.71051 0.95707,-3.259651 0.8603,-1.549141 1.82694,-2.601389 2.15873,-2.350276 l 17.35485,13.134307"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       transform="matrix(0.77661521,0.58778195,-0.5035479,0.90652826,0,0)"
+       
+       x="161.90433"
+       y="-17.682194"
+       >DN<tspan
+   font-size="2.64251px"
+   x="165.2872"
+   y="-17.684744"
+   
+   >-</tspan><tspan
+   font-size="2.64251px"
+   x="166.10341"
+   y="-17.66626"
+   
+   >2</tspan></text>
+    <path
+       d="m 69.67739,37.613626 c 0,-1.679603 1.166458,-3.041182 2.605359,-3.041182 1.438898,0 2.605356,1.361579 2.605356,3.041182 0,1.679599 -1.166458,3.041182 -2.605356,3.041182 -1.438901,0 -2.605359,-1.361583 -2.605359,-3.041182 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="4.82545px"
+       
+       x="76.602852"
+       y="36.595104"
+       
+       transform="scale(0.92557641,1.0804078)">R</text>
+    <path
+       d="m 122.10353,37.303301 c 0,-1.713861 1.16656,-3.103246 2.60536,-3.103246 1.43879,0 2.60535,1.389385 2.60535,3.103246 0,1.71386 -1.16656,3.103246 -2.60535,3.103246 -1.4388,0 -2.60536,-1.389386 -2.60536,-3.103246 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="4.82545px"
+       
+       x="133.48183"
+       y="36.365314"
+       
+       transform="scale(0.92557641,1.0804078)">E</text>
+    <path
+       d="m 69.67739,105.38855 c 0,-1.6796 1.166458,-3.04119 2.605359,-3.04119 1.438898,0 2.605356,1.36159 2.605356,3.04119 0,1.67947 -1.166458,3.04118 -2.605356,3.04118 -1.438901,0 -2.605359,-1.36171 -2.605359,-3.04118 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="4.82545px"
+       
+       x="76.602852"
+       y="99.325974"
+       
+       transform="scale(0.92557641,1.0804078)">R</text>
+    <path
+       d="m 122.10353,105.38855 c 0,-1.6796 1.16656,-3.04119 2.60536,-3.04119 1.43879,0 2.60535,1.36159 2.60535,3.04119 0,1.67947 -1.16656,3.04118 -2.60535,3.04118 -1.4388,0 -2.60536,-1.36171 -2.60536,-3.04118 z"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="4.82545px"
+       
+       x="133.48183"
+       y="99.325974"
+       
+       transform="scale(0.92557641,1.0804078)">E</text>
+    <rect
+       x="76.802231"
+       y="26.87639"
+       width="8.0819197"
+       height="7.199522"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.3787px"
+       
+       x="85.515114"
+       y="26.714422"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS<tspan
+   font-size="1.3787px"
+   x="85.112999"
+   y="28.322903"
+   
+   >S</tspan><tspan
+   font-size="1.3787px"
+   x="85.883728"
+   y="28.322903"
+   
+   >-</tspan><tspan
+   font-size="1.3787px"
+   x="86.4534"
+   y="28.322903"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="85.698753"
+   y="30.505838"
+   
+   >101</tspan></text>
+    <rect
+       x="76.802231"
+       y="19.676861"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49359px"
+       
+       x="86.621643"
+       y="20.395372"
+       
+       transform="scale(0.92557641,1.0804078)">IP<tspan
+   font-size="1.49359px"
+   x="84.962219"
+   y="22.11875"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.49359px"
+   x="84.962219"
+   y="23.842125"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="76.802231"
+       y="12.477315"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.60848px"
+       
+       x="85.096222"
+       y="14.650792"
+       
+       transform="scale(0.92557641,1.0804078)">DATA <tspan
+   font-size="1.60848px"
+   x="86.838737"
+   y="16.603941"
+   
+   >1</tspan></text>
+    <rect
+       x="84.884148"
+       y="26.87639"
+       width="8.0819197"
+       height="7.199522"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.3787px"
+       
+       x="94.25412"
+       y="26.714422"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS<tspan
+   font-size="1.3787px"
+   x="93.852005"
+   y="28.322903"
+   
+   >S</tspan><tspan
+   font-size="1.3787px"
+   x="94.622734"
+   y="28.322903"
+   
+   >-</tspan><tspan
+   font-size="1.3787px"
+   x="95.192406"
+   y="28.322903"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="94.437767"
+   y="30.505838"
+   
+   >104</tspan></text>
+    <rect
+       x="84.884148"
+       y="19.676861"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49359px"
+       
+       x="95.360649"
+       y="20.395372"
+       
+       transform="scale(0.92557641,1.0804078)">IP<tspan
+   font-size="1.49359px"
+   x="93.701233"
+   y="22.11875"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.49359px"
+   x="93.701233"
+   y="23.842125"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="84.884148"
+       y="12.477315"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.60848px"
+       
+       x="93.835228"
+       y="14.650792"
+       
+       transform="scale(0.92557641,1.0804078)">DATA <tspan
+   font-size="1.60848px"
+   x="95.577766"
+   y="16.603941"
+   
+   >2</tspan></text>
+    <rect
+       x="76.908569"
+       y="95.271973"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.3787px"
+       
+       x="85.651154"
+       y="90.019753"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS<tspan
+   font-size="1.3787px"
+   x="85.249039"
+   y="91.628235"
+   
+   >S</tspan><tspan
+   font-size="1.3787px"
+   x="86.019775"
+   y="91.628235"
+   
+   >-</tspan><tspan
+   font-size="1.3787px"
+   x="86.589439"
+   y="91.628235"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="85.834801"
+   y="93.81118"
+   
+   >101</tspan></text>
+    <rect
+       x="84.990486"
+       y="95.271973"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.3787px"
+       
+       x="94.390167"
+       y="90.019753"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS<tspan
+   font-size="1.3787px"
+   x="93.988052"
+   y="91.628235"
+   
+   >S</tspan><tspan
+   font-size="1.3787px"
+   x="94.758774"
+   y="91.628235"
+   
+   >-</tspan><tspan
+   font-size="1.3787px"
+   x="95.328453"
+   y="91.628235"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="94.573807"
+   y="93.81118"
+   
+   >104</tspan></text>
+    <rect
+       x="76.908569"
+       y="88.072433"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49359px"
+       
+       x="86.757553"
+       y="83.700706"
+       
+       transform="scale(0.92557641,1.0804078)">IP<tspan
+   font-size="1.49359px"
+   x="85.09816"
+   y="85.42408"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.49359px"
+   x="85.09816"
+   y="87.147461"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="84.990486"
+       y="88.072433"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49359px"
+       
+       x="95.496559"
+       y="83.700706"
+       
+       transform="scale(0.92557641,1.0804078)">IP<tspan
+   font-size="1.49359px"
+   x="93.837166"
+   y="85.42408"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.49359px"
+   x="93.837166"
+   y="87.147461"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="76.908569"
+       y="80.997025"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.60848px"
+       
+       x="85.232262"
+       y="77.956123"
+       
+       transform="scale(0.92557641,1.0804078)">DATA <tspan
+   font-size="1.60848px"
+   x="86.974777"
+   y="79.909279"
+   
+   >1</tspan></text>
+    <rect
+       x="84.990486"
+       y="80.997025"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.60848px"
+       
+       x="93.971275"
+       y="77.956123"
+       
+       transform="scale(0.92557641,1.0804078)">DATA <tspan
+   font-size="1.60848px"
+   x="95.713791"
+   y="79.909279"
+   
+   >2</tspan></text>
+    <rect
+       x="104.13187"
+       y="26.87639"
+       width="8.0819197"
+       height="7.199522"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.3787px"
+       
+       x="115.13134"
+       y="26.714422"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS<tspan
+   font-size="1.3787px"
+   x="114.72923"
+   y="28.322903"
+   
+   >S</tspan><tspan
+   font-size="1.3787px"
+   x="115.49995"
+   y="28.322903"
+   
+   >-</tspan><tspan
+   font-size="1.3787px"
+   x="116.06962"
+   y="28.322903"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="115.31496"
+   y="30.505838"
+   
+   >101</tspan></text>
+    <rect
+       x="104.13187"
+       y="19.676861"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49359px"
+       
+       x="116.23774"
+       y="20.395372"
+       
+       transform="scale(0.92557641,1.0804078)">IP<tspan
+   font-size="1.49359px"
+   x="114.57832"
+   y="22.11875"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.49359px"
+   x="114.57832"
+   y="23.842125"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="112.2138"
+       y="19.676861"
+       width="8.188261"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49359px"
+       
+       x="124.97757"
+       y="20.395372"
+       
+       transform="scale(0.92557641,1.0804078)">IP<tspan
+   font-size="1.49359px"
+   x="123.31812"
+   y="22.11875"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.49359px"
+   x="123.31812"
+   y="23.842125"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="104.13187"
+       y="12.477315"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.60848px"
+       
+       x="114.71313"
+       y="14.650792"
+       
+       transform="scale(0.92557641,1.0804078)">DATA <tspan
+   font-size="1.60848px"
+   x="116.45565"
+   y="16.603941"
+   
+   >1</tspan></text>
+    <rect
+       x="112.2138"
+       y="12.477315"
+       width="8.188261"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.60848px"
+       
+       x="123.4518"
+       y="14.650792"
+       
+       transform="scale(0.92557641,1.0804078)">DATA <tspan
+   font-size="1.60848px"
+   x="125.19431"
+   y="16.603941"
+   
+   >2</tspan></text>
+    <rect
+       x="104.23822"
+       y="95.271973"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.3787px"
+       
+       x="115.24506"
+       y="90.134636"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS<tspan
+   font-size="1.3787px"
+   x="114.84296"
+   y="91.743126"
+   
+   >S</tspan><tspan
+   font-size="1.3787px"
+   x="115.61371"
+   y="91.743126"
+   
+   >-</tspan><tspan
+   font-size="1.3787px"
+   x="116.18338"
+   y="91.743126"
+   
+   >label</tspan><tspan
+   font-size="1.60848px"
+   x="115.6298"
+   y="93.696281"
+   
+   >101</tspan></text>
+    <rect
+       x="112.32014"
+       y="95.271973"
+       width="8.188261"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.3787px"
+       
+       x="123.98489"
+       y="90.019753"
+       
+       transform="scale(0.92557641,1.0804078)">MPLS<tspan
+   font-size="1.3787px"
+   x="123.58278"
+   y="91.628235"
+   
+   >S</tspan><tspan
+   font-size="1.3787px"
+   x="124.35351"
+   y="91.628235"
+   
+   >-</tspan><tspan
+   font-size="1.3787px"
+   x="124.92318"
+   y="91.628235"
+   
+   >label</tspan><tspan
+   font-size="1.83826px"
+   x="124.16853"
+   y="93.81118"
+   
+   >104</tspan></text>
+    <rect
+       x="104.23822"
+       y="88.072433"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49359px"
+       
+       x="116.35262"
+       y="83.700706"
+       
+       transform="scale(0.92557641,1.0804078)">IP<tspan
+   font-size="1.49359px"
+   x="114.69321"
+   y="85.42408"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.49359px"
+   x="114.69321"
+   y="87.147461"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="112.32014"
+       y="88.072433"
+       width="8.188261"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49359px"
+       
+       x="125.09129"
+       y="83.700706"
+       
+       transform="scale(0.92557641,1.0804078)">IP<tspan
+   font-size="1.49359px"
+   x="123.43187"
+   y="85.42408"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.49359px"
+   x="123.43187"
+   y="87.147461"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="104.23822"
+       y="80.997025"
+       width="8.0819197"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.60848px"
+       
+       x="114.82687"
+       y="77.956123"
+       
+       transform="scale(0.92557641,1.0804078)">DATA <tspan
+   font-size="1.60848px"
+   x="116.56939"
+   y="79.909279"
+   
+   >1</tspan></text>
+    <rect
+       x="112.32014"
+       y="80.997025"
+       width="8.188261"
+       height="7.1995463"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.60848px"
+       
+       x="123.56553"
+       y="77.956123"
+       
+       transform="scale(0.92557641,1.0804078)">DATA <tspan
+   font-size="1.60848px"
+   x="125.30804"
+   y="79.909279"
+   
+   >2</tspan><tspan
+   font-size="3.79143px"
+   x="163.70938"
+   y="39.23761"
+   
+   >Note: S and A labels in this</tspan><tspan
+   font-size="3.79143px"
+   x="163.70938"
+   y="43.718391"
+   
+   >diagram include d-CWs of their</tspan><tspan
+   font-size="3.79143px"
+   x="163.70938"
+   y="48.199173"
+   
+   >own.</tspan></text>
+    <path
+       d="m 73.744939,64.984269 c -0.396441,0 -0.717803,-1.500481 -0.717803,-3.351508 0,-1.851026 0.321362,-3.351507 0.717803,-3.351507 0.396437,0 0.717799,1.500481 0.717799,3.351507 0,1.851027 -0.321362,3.351508 -0.717799,3.351508 h -5.157545 c -0.396437,0 -0.717799,-1.500481 -0.717799,-3.351508 0,-1.851026 0.321362,-3.351507 0.717799,-3.351507 h 5.157545"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="74.834793"
+       y="56.930943"
+       
+       transform="scale(0.92557641,1.0804078)">DN<tspan
+   font-size="2.64251px"
+   x="78.219315"
+   y="56.930943"
+   
+   >-1</tspan></text>
+    <path
+       d="m 73.532256,72.183801 c -0.396442,0 -0.717804,-1.500481 -0.717804,-3.351507 0,-1.851022 0.321362,-3.351508 0.717804,-3.351508 0.39644,0 0.717802,1.500486 0.717802,3.351508 0,1.851026 -0.321362,3.351507 -0.717802,3.351507 h -5.051201 c -0.396441,0 -0.717804,-1.500481 -0.717804,-3.351507 0,-1.851022 0.321363,-3.351508 0.717804,-3.351508 h 5.051201"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="74.699776"
+       y="66.007385"
+       
+       transform="scale(0.92557641,1.0804078)">DN<tspan
+   font-size="2.64251px"
+   x="78.084297"
+   y="66.007385"
+   
+   >-2</tspan></text>
+    <path
+       d="m 119.89695,72.059672 c -0.80713,0 -1.46218,-3.056574 -1.46218,-6.827143 0,-3.770572 0.65505,-6.827147 1.46218,-6.827147 0.80713,0 1.46219,3.056575 1.46219,6.827147 0,3.770569 -0.65506,6.827143 -1.46219,6.827143 H 77.413703 c -0.807551,0 -1.462189,-3.056574 -1.462189,-6.827143 0,-3.770572 0.654638,-6.827147 1.462189,-6.827147 h 42.483247"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="98.219147"
+       y="61.411716"
+       
+       transform="scale(0.92557641,1.0804078)">Aggregated DN-1</text>
+    <path
+       d="m 128.51058,65.108397 c -0.39665,0 -0.71781,-1.500481 -0.71781,-3.351508 0,-1.851022 0.32116,-3.351507 0.71781,-3.351507 0.39665,0 0.7178,1.500485 0.7178,3.351507 0,1.851027 -0.32115,3.351508 -0.7178,3.351508 h -5.0512 c -0.39665,0 -0.7178,-1.500481 -0.7178,-3.351508 0,-1.851022 0.32115,-3.351507 0.7178,-3.351507 h 5.0512"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="134.16888"
+       y="56.816048"
+       
+       transform="scale(0.92557641,1.0804078)">DN<tspan
+   font-size="2.64251px"
+   x="137.55341"
+   y="56.816048"
+   
+   >-1</tspan></text>
+    <path
+       d="m 128.40423,72.183801 c -0.39665,0 -0.71779,-1.500481 -0.71779,-3.351507 0,-1.851022 0.32114,-3.351508 0.71779,-3.351508 0.39666,0 0.71781,1.500486 0.71781,3.351508 0,1.851026 -0.32115,3.351507 -0.71781,3.351507 h -5.0512 c -0.39665,0 -0.71779,-1.500481 -0.71779,-3.351507 0,-1.851022 0.32114,-3.351508 0.71779,-3.351508 h 5.0512"
+       stroke="#000000"
+       stroke-width="0.26808"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="133.99425"
+       y="66.122276"
+       
+       transform="scale(0.92557641,1.0804078)">DN<tspan
+   font-size="2.64251px"
+   x="137.37877"
+   y="66.122276"
+   
+   >-2</tspan></text>
+    <path
+       d="m 63.775464,57.286725 c 0,-0.307594 0.21364,-0.557095 0.477259,-0.557095 H 78.07961 c 0.263515,0 0.477259,0.249501 0.477259,0.557095 v 17.132907 c 0,0.307716 -0.213744,0.557095 -0.477259,0.557095 H 64.252723 c -0.263619,0 -0.477259,-0.249379 -0.477259,-0.557095 z"
+       stroke="#000000"
+       stroke-width="0.53616"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.14465, 1.60848"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 118.11574,57.314781 c 0,-0.32311 0.22438,-0.585151 0.50087,-0.585151 h 14.52406 c 0.27649,0 0.50087,0.262041 0.50087,0.585151 v 16.952667 c 0,0.32311 -0.22438,0.58515 -0.50087,0.58515 h -14.52406 c -0.27649,0 -0.50087,-0.26204 -0.50087,-0.58515 z"
+       stroke="#000000"
+       stroke-width="0.53616"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.14465, 1.60848"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.64251px"
+       
+       x="70.38549"
+       y="74.509369"
+       
+       transform="scale(0.92557641,1.0804078)">aggregation<tspan
+   font-size="2.64251px"
+   x="127.93602"
+   y="74.394478"
+   
+   >disaggregation</tspan></text>
+  </g>
+</svg>
+</artwork>
+</artset>
+        </figure>
+        <figure anchor="example-detnet-json-service-aggregation-c-3">
+          <name>Example C-3 DetNet JSON Relay Service Sub-Layer Aggregation</name>
+          <artwork name="" type="" align="left" alt=""><![CDATA[
+{
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "eth0",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth1",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth2",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth3",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth4",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      }
+    ]
+  },
+  "ietf-detnet:detnet": {
+    "traffic-profile": [
+      {
+        "profile-name": "pf-1",
+        "traffic-requirements": {
+          "min-bandwidth": "100000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 100000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "member-services": [
+          "ssl-1",
+          "ssl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-2",
+        "traffic-requirements": {
+          "min-bandwidth": "200000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 100000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "member-services": [
+          "asl-1"
+        ]
+      },
+      {
+        "profile-name": "pf-3",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 1,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "fsl-1",
+          "fsl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-4",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 2,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "fsl-3",
+          "fsl-4"
+        ]
+      }
+    ],
+    "service-sub-layer": {
+      "service-sub-layer-list": [
+        {
+          "name": "ssl-1",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "none",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 100
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "aggregation-service-sub-layer": "asl-1",
+              "service-label": {
+                "mpls-label-stack": {
+                  "entry": [
+                    {
+                      "id": 0,
+                      "label": 101
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "ssl-2",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "none",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 103
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "aggregation-service-sub-layer": "asl-1",
+              "service-label": {
+                "mpls-label-stack": {
+                  "entry": [
+                    {
+                      "id": 0,
+                      "label": 104
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "asl-1",
+          "service-rank": 10,
+          "traffic-profile": "pf-2",
+          "service-protection": {
+            "service-protection-type": "replication",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-initiation",
+          "incoming-type": {
+            "service-aggregation": {
+              "service-sub-layer": [
+                "ssl-1",
+                "ssl-2"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 1000
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-3",
+                    "fsl-4"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "forwarding-sub-layer": {
+      "forwarding-sub-layer-list": [
+        {
+          "name": "fsl-1",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth0",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10000
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-2",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10006
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-2"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-3",
+          "traffic-profile": "pf-4",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "asl-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth2",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20000
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "fsl-4",
+          "traffic-profile": "pf-4",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "asl-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth3",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20001
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+]]></artwork>
+        </figure>
+        <figure anchor="example-detnet-json-service-disaggregation-c-3">
+          <name>Example C-3 DetNet JSON Relay Service Sub-Layer Disaggregation</name>
+          <artwork name="" type="" align="left" alt=""><![CDATA[
+{
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "eth0",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth1",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth2",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth3",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth4",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      }
+    ]
+  },
+  "ietf-detnet:detnet": {
+    "traffic-profile": [
+      {
+        "profile-name": "pf-1",
+        "traffic-requirements": {
+          "min-bandwidth": "100000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 100000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "member-services": [
+          "ssl-1",
+          "ssl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-2",
+        "traffic-requirements": {
+          "min-bandwidth": "200000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 100000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "member-services": [
+          "asl-1"
+        ]
+      },
+      {
+        "profile-name": "pf-3",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 1,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "fsl-3",
+          "fsl-4"
+        ]
+      },
+      {
+        "profile-name": "pf-4",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 2,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "fsl-1",
+          "fsl-2"
+        ]
+      }
+    ],
+    "service-sub-layer": {
+      "service-sub-layer-list": [
+        {
+          "name": "ssl-1",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "none",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 101
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 102
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-3"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "ssl-2",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "none",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 104
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 105
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-4"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "asl-1",
+          "service-rank": 10,
+          "traffic-profile": "pf-2",
+          "service-protection": {
+            "service-protection-type": "elimination",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-termination",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 1000
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-disaggregation": {
+              "service-sub-layer": [
+                "ssl-1",
+                "ssl-2"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "forwarding-sub-layer": {
+      "forwarding-sub-layer-list": [
+        {
+          "name": "fsl-1",
+          "traffic-profile": "pf-4",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth0",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20002
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "asl-1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-2",
+          "traffic-profile": "pf-4",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20003
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "asl-1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-3",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth2",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10005
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "fsl-4",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-2"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth3",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10011
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+]]></artwork>
+        </figure>
+      </section>
+      <section numbered="true" toc="default">
+              <name>Example C-4 JSON Relay Service Sub-Layer Aggregation/Disaggregation</name>
+        <t>
+                This illustrates the Relay node 1 aggregating the 
+                forwarding sub-layers of DetNet flow 1 and 2 into a service sub-layer of Aggregated DetNet flow 1.
+                This also illustrates the Relay node 2 disaggregating the service sub-layer of 
+                Aggregated DetNet flow 1 to forwarding sub-layers of DetNet flow 1 and 2.
+                A diagram illustrating both aggregation and disaggregation is shown and then the 
+                corresponding JSON operational data follows.
+        </t>
+        <figure anchor="case-c4">
+                <name>Case C-4 Example JSON Service Aggregation/Disaggregation</name>
+          <artset>
+            <artwork align="left" type="ascii-art" name="" alt=""><![CDATA[
+        
+Please consult the PDF or HTML versions for the Case C-4 Diagram
+
+]]></artwork>
+        <artwork type="svg">
+<svg
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="210mm"
+   height="155mm"
+   viewBox="0 0 210 155"
+   version="1.1"
+   >
+   <g
+     >
+    <text
+       font-size="3.49204px"
+       
+       x="234.2603"
+       y="121.01194"
+       
+       transform="scale(0.85569064,1.1686467)">18<tspan
+   font-size="2.86847px"
+   x="10.878091"
+   y="68.63131"
+   
+   >Source 1</tspan><tspan
+   font-size="2.86847px"
+   x="11.930708"
+   y="71.499771"
+   
+   >192.0.2.1</tspan></text>
+    <path
+       d="m 17.213959,70.298755 c 0,-0.404638 -0.240181,-0.73266 -0.536457,-0.73266 H 10.70703 c -0.296276,0 -0.536456,0.328022 -0.536456,0.73266 v 6.405131 c 0,0.404633 0.24018,0.732652 0.536456,0.732652 h 5.970472 c 0.296276,0 0.536457,-0.328019 0.536457,-0.732652 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 15.980829,70.003341 v 0.848619 h -1.423617 l -0.758236,1.904224 -0.773709,-1.904224 h -1.408139 v -0.848619 l -0.91299,1.076298 0.91299,1.076294 v -0.724428 h 1.005818 l 0.866547,2.090501 -0.866547,2.111202 h -1.005818 v -0.786519 l -0.91299,1.076293 0.91299,1.076293 V 76.19205 h 1.408139 l 0.773709,-1.945615 0.758236,1.945615 h 1.423617 v 0.765834 l 0.912974,-1.034902 -0.912974,-1.076293 v 0.786519 h -0.990344 l -0.882021,-2.111202 0.866547,-2.090501 h 1.005818 v 0.703731 l 0.912974,-1.055597 z"
+       stroke="#000000"
+       stroke-width="0.218253"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="42.813812"
+       y="68.63131"
+       
+       transform="scale(0.85569064,1.1686467)">Ingress 1<tspan
+   font-size="2.86847px"
+   x="43.995293"
+   y="71.499771"
+   
+   >192.0.2.2</tspan></text>
+    <path
+       d="m 44.640519,70.298759 c 0,-0.404639 -0.24018,-0.732664 -0.536462,-0.732664 h -5.863746 c -0.296281,0 -0.536457,0.328025 -0.536457,0.732664 v 6.405112 c 0,0.404648 0.240176,0.732667 0.536457,0.732667 h 5.863746 c 0.296282,0 0.536462,-0.328019 0.536462,-0.732667 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 43.49837,70.003341 v 0.848619 h -1.448167 l -0.771304,1.904224 -0.787048,-1.904224 h -1.432437 v -0.848619 l -0.92871,1.076298 0.92871,1.076294 v -0.724428 h 1.023164 l 0.8815,2.090501 -0.8815,2.111202 h -1.023164 v -0.786519 l -0.92871,1.076293 0.92871,1.076293 V 76.19205 h 1.432437 l 0.787048,-1.945615 0.771304,1.945615 h 1.448167 v 0.765834 l 0.928714,-1.034902 -0.928714,-1.076293 v 0.786519 h -1.00742 l -0.897234,-2.111202 0.881494,-2.090501 h 1.02316 v 0.703731 l 0.928714,-1.055597 z"
+       stroke="#000000"
+       stroke-width="0.218253"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="75.877464"
+       y="72.123352"
+       
+       transform="scale(0.85569064,1.1686467)">Relay 1<tspan
+   font-size="2.86847px"
+   x="76.059341"
+   y="74.991814"
+   
+   >192.0.2.3</tspan></text>
+    <path
+       d="m 72.067082,70.298752 c 0,-0.404635 -0.240179,-0.732657 -0.536455,-0.732657 h -5.863774 c -0.296281,0 -0.536461,0.328022 -0.536461,0.732657 v 6.405134 c 0,0.404633 0.24018,0.732652 0.536461,0.732652 h 5.863774 c 0.296276,0 0.536455,-0.328019 0.536455,-0.732652 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 70.92493,70.003341 V 70.85196 H 69.476765 L 68.70546,72.756184 67.918414,70.85196 h -1.432435 v -0.848619 l -0.928715,1.076298 0.928715,1.076294 v -0.724428 h 1.02316 l 0.881503,2.090501 -0.881503,2.111202 h -1.02316 v -0.786519 l -0.928715,1.076293 0.928715,1.076293 V 76.19205 h 1.432435 l 0.787046,-1.945615 0.771305,1.945615 h 1.448165 v 0.765834 l 0.928715,-1.034902 -0.928715,-1.076293 v 0.786519 h -1.007419 l -0.897232,-2.111202 0.881491,-2.090501 h 1.02316 v 0.703731 l 0.928715,-1.055597 z"
+       stroke="#000000"
+       stroke-width="0.218253"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="140.00383"
+       y="72.123352"
+       
+       transform="scale(0.85569064,1.1686467)">Relay 2<tspan
+   font-size="2.86847px"
+   x="140.18571"
+   y="74.991814"
+   
+   >192.0.2.6</tspan></text>
+    <path
+       d="m 126.9202,70.298759 c 0,-0.404639 -0.24018,-0.732664 -0.53646,-0.732664 H 120.52 c -0.29628,0 -0.53646,0.328025 -0.53646,0.732664 v 6.405112 c 0,0.404648 0.24018,0.732667 0.53646,0.732667 h 5.86374 c 0.29628,0 0.53646,-0.328019 0.53646,-0.732667 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 125.77806,70.14909 v 0.83094 h -1.44817 l -0.7713,1.864552 -0.78705,-1.864552 h -1.43244 v -0.83094 l -0.92871,1.053874 0.92871,1.053871 v -0.709336 h 1.02317 l 0.8815,2.046944 -0.8815,2.067216 h -1.02317 v -0.770138 l -0.92871,1.053877 0.92871,1.053877 v -0.790409 h 1.43244 l 0.78705,-1.905078 0.7713,1.905078 h 1.44817 v 0.749866 l 0.92871,-1.013334 -0.92871,-1.053877 v 0.770138 h -1.00742 l -0.89724,-2.067216 0.8815,-2.046944 h 1.02316 v 0.689077 l 0.92871,-1.033612 z"
+       stroke="#000000"
+       stroke-width="0.218253"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="171.48584"
+       y="68.63131"
+       
+       transform="scale(0.85569064,1.1686467)">Egress 1<tspan
+   font-size="2.86847px"
+   x="172.24828"
+   y="71.499771"
+   
+   >192.0.2.77</tspan></text>
+    <path
+       d="m 154.34677,70.298752 c 0,-0.404635 -0.24018,-0.732657 -0.53646,-0.732657 h -5.86377 c -0.29628,0 -0.53646,0.328022 -0.53646,0.732657 v 6.405134 c 0,0.404633 0.24018,0.732652 0.53646,0.732652 h 5.86377 c 0.29628,0 0.53646,-0.328019 0.53646,-0.732652 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 153.22036,70.003341 v 0.848619 h -1.42362 l -0.75824,1.904224 -0.7737,-1.904224 h -1.40815 v -0.848619 l -0.91298,1.076298 0.91298,1.076294 v -0.724428 h 1.00582 l 0.86655,2.090501 -0.86655,2.111202 h -1.00582 v -0.786519 l -0.91298,1.076293 0.91298,1.076293 V 76.19205 h 1.40815 l 0.7737,-1.945615 0.75824,1.945615 h 1.42362 v 0.765834 l 0.91297,-1.034902 -0.91297,-1.076293 v 0.786519 h -0.99035 l -0.88202,-2.111202 0.86655,-2.090501 h 1.00582 v 0.703731 l 0.91297,-1.055597 z"
+       stroke="#000000"
+       stroke-width="0.218253"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="107.06764"
+       y="84.96907"
+       
+       transform="scale(0.85569064,1.1686467)">Transit 2<tspan
+   font-size="2.86847px"
+   x="108.12107"
+   y="87.837547"
+   
+   >192.0.2.5</tspan></text>
+    <path
+       d="m 99.493643,89.246081 c 0,-0.404634 -0.240179,-0.732653 -0.536455,-0.732653 h -5.863773 c -0.296282,0 -0.536462,0.328019 -0.536462,0.732653 v 6.405145 c 0,0.404618 0.24018,0.732644 0.536462,0.732644 h 5.863773 c 0.296276,0 0.536455,-0.328026 0.536455,-0.732644 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 98.351495,89.096418 v 0.830939 h -1.448167 l -0.771295,1.864551 -0.787047,-1.864551 h -1.432424 v -0.830939 l -0.928714,1.053877 0.928714,1.05387 v -0.709337 h 1.02316 l 0.881492,2.046946 -0.881492,2.06721 h -1.02316 v -0.77013 l -0.928714,1.053877 0.928714,1.053877 v -0.79041 h 1.432424 l 0.787047,-1.90508 0.771295,1.90508 h 1.448167 v 0.749866 l 0.928712,-1.013333 -0.928712,-1.053877 v 0.77013 h -1.007422 l -0.897232,-2.06721 0.881492,-2.046946 h 1.023162 v 0.68908 l 0.928712,-1.033613 z"
+       stroke="#000000"
+       stroke-width="0.218253"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="107.06764"
+       y="52.293537"
+       
+       transform="scale(0.85569064,1.1686467)">Transit 1<tspan
+   font-size="2.86847px"
+   x="108.12107"
+   y="55.162003"
+   
+   >192.0.2.4</tspan></text>
+    <path
+       d="m 99.493643,51.205671 c 0,-0.404634 -0.240179,-0.732655 -0.536455,-0.732655 h -5.863773 c -0.296282,0 -0.536462,0.328021 -0.536462,0.732655 v 6.40514 c 0,0.404627 0.24018,0.732649 0.536462,0.732649 h 5.863773 c 0.296276,0 0.536455,-0.328022 0.536455,-0.732649 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 98.351495,51.056011 v 0.830942 h -1.448167 l -0.771295,1.864549 -0.787047,-1.864549 h -1.432424 v -0.830942 l -0.928714,1.053878 0.928714,1.053881 v -0.709344 h 1.02316 l 0.881492,2.046953 -0.881492,2.067226 h -1.02316 v -0.770136 l -0.928714,1.053866 0.928714,1.053879 v -0.79041 h 1.432424 l 0.787047,-1.905081 0.771295,1.905081 h 1.448167 v 0.749877 l 0.928712,-1.013346 -0.928712,-1.053866 v 0.770136 h -1.007422 l -0.897232,-2.067226 0.881492,-2.046953 h 1.023162 v 0.68907 l 0.928712,-1.033607 z"
+       stroke="#000000"
+       stroke-width="0.218253"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="200.51096"
+       y="68.63131"
+       
+       transform="scale(0.85569064,1.1686467)">Destination 1<tspan
+   font-size="2.86847px"
+   x="204.31146"
+   y="71.499771"
+   
+   >192.0.2.88</tspan></text>
+    <path
+       d="m 181.77333,70.298752 c 0,-0.404635 -0.24018,-0.732657 -0.53646,-0.732657 h -5.86377 c -0.29628,0 -0.53646,0.328022 -0.53646,0.732657 v 6.405134 c 0,0.404633 0.24018,0.732652 0.53646,0.732652 h 5.86377 c 0.29628,0 0.53646,-0.328019 0.53646,-0.732652 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 180.64692,70.003341 v 0.848619 h -1.42362 l -0.75823,1.904224 -0.77371,-1.904224 h -1.40814 v -0.848619 l -0.91299,1.076298 0.91299,1.076294 v -0.724428 h 1.00582 l 0.86654,2.090501 -0.86654,2.111202 h -1.00582 v -0.786519 l -0.91299,1.076293 0.91299,1.076293 V 76.19205 h 1.40814 l 0.77371,-1.945615 0.75823,1.945615 h 1.42362 v 0.765834 l 0.91297,-1.034902 -0.91297,-1.076293 v 0.786519 h -0.99034 l -0.88203,-2.111202 0.86655,-2.090501 h 1.00582 v 0.703731 l 0.91297,-1.055597 z"
+       stroke="#000000"
+       stroke-width="0.218253"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 17.213959,73.50131 H 37.687833"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 44.640519,73.50131 H 65.114395"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 72.067082,73.450006 92.540957,54.408231"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 99.493643,54.408231 119.96752,73.450006"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 126.9202,73.50131 h 20.47388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 154.34677,73.50131 h 20.47387"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 99.493643,92.507663 119.96752,73.501308"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 72.067082,73.50131 92.540956,92.507818"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="19.34832"
+       y="3.396188"
+       width="16.221159"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="26.730089"
+       y="7.6452875"
+       
+       transform="scale(0.85569064,1.1686467)">DATA 1</text>
+    <rect
+       x="74.201447"
+       y="45.663311"
+       width="16.221159"
+       height="8.5991583"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="89.847633"
+       y="42.316277"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS F<tspan
+   font-size="1.99545px"
+   x="97.049973"
+   y="42.316277"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="97.886612"
+   y="42.316277"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="93.249466"
+   y="44.810593"
+   
+   >20000</tspan></text>
+    <rect
+       x="74.308167"
+       y="134.57001"
+       width="16.221159"
+       height="8.4534101"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="89.9953"
+       y="118.26819"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS F<tspan
+   font-size="1.99545px"
+   x="97.197632"
+   y="118.26819"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="98.034264"
+   y="118.26819"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="93.397133"
+   y="120.7625"
+   
+   >20001</tspan></text>
+    <rect
+       x="101.62801"
+       y="45.663311"
+       width="16.327875"
+       height="8.5991583"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="122.00236"
+       y="42.316277"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS F<tspan
+   font-size="1.99545px"
+   x="129.2047"
+   y="42.316277"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="130.04134"
+   y="42.316277"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="125.40419"
+   y="44.810593"
+   
+   >20002</tspan></text>
+    <rect
+       x="101.73473"
+       y="134.57001"
+       width="16.327875"
+       height="8.4534101"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="122.12083"
+       y="118.26819"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS F<tspan
+   font-size="1.99545px"
+   x="129.32318"
+   y="118.26819"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="130.15982"
+   y="118.26819"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="125.52267"
+   y="120.7625"
+   
+   >20003</tspan></text>
+    <rect
+       x="156.2677"
+       y="3.396188"
+       width="16.221159"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="186.78099"
+       y="7.6452875"
+       
+       transform="scale(0.85569064,1.1686467)">DATA 1</text>
+    <rect
+       x="19.34832"
+       y="11.849612"
+       width="16.221159"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="27.057476"
+       y="13.631644"
+       
+       transform="scale(0.85569064,1.1686467)">IP <tspan
+   font-size="1.99545px"
+   x="30.767769"
+   y="13.631644"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.99545px"
+   x="30.73139"
+   y="16.250677"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="156.2677"
+       y="11.849612"
+       width="16.221159"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="187.10774"
+       y="13.631644"
+       
+       transform="scale(0.85569064,1.1686467)">IP <tspan
+   font-size="1.99545px"
+   x="190.81804"
+   y="13.631644"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.99545px"
+   x="190.78166"
+   y="16.250677"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="46.881599"
+       y="20.448786"
+       width="16.221159"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="57.863644"
+       y="20.615728"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS S<tspan
+   font-size="1.99545px"
+   x="65.175102"
+   y="20.615728"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="66.011749"
+   y="20.615728"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="62.48333"
+   y="23.110044"
+   
+   >100</tspan></text>
+    <rect
+       x="46.881599"
+       y="28.756462"
+       width="16.221159"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="57.918274"
+       y="27.724531"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS F<tspan
+   font-size="1.99545px"
+   x="65.120605"
+   y="27.724531"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="65.957253"
+   y="27.724531"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="61.320107"
+   y="30.218847"
+   
+   >10000</tspan></text>
+    <rect
+       x="46.881599"
+       y="3.396188"
+       width="16.221159"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="58.900402"
+       y="7.6452875"
+       
+       transform="scale(0.85569064,1.1686467)">DATA 1</text>
+    <rect
+       x="46.881599"
+       y="11.849612"
+       width="16.221159"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="59.227787"
+       y="13.631644"
+       
+       transform="scale(0.85569064,1.1686467)">IP <tspan
+   font-size="1.99545px"
+   x="62.938076"
+   y="13.631644"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.99545px"
+   x="62.901711"
+   y="16.250677"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="129.05457"
+       y="20.448786"
+       width="16.221159"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="153.97824"
+       y="20.615728"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS S<tspan
+   font-size="1.99545px"
+   x="161.2897"
+   y="20.615728"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="162.12634"
+   y="20.615728"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="158.5979"
+   y="23.110044"
+   
+   >102</tspan></text>
+    <rect
+       x="129.05457"
+       y="28.756462"
+       width="16.221159"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="154.03188"
+       y="27.724531"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS F<tspan
+   font-size="1.99545px"
+   x="161.23421"
+   y="27.724531"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="162.07085"
+   y="27.724531"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="157.4337"
+   y="30.218847"
+   
+   >10005</tspan></text>
+    <rect
+       x="129.05457"
+       y="3.396188"
+       width="16.221159"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="155.01462"
+       y="7.6452875"
+       
+       transform="scale(0.85569064,1.1686467)">DATA 1</text>
+    <rect
+       x="129.05457"
+       y="11.849612"
+       width="16.221159"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="155.34138"
+       y="13.631644"
+       
+       transform="scale(0.85569064,1.1686467)">IP <tspan
+   font-size="1.99545px"
+   x="159.05168"
+   y="13.631644"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.99545px"
+   x="159.0153"
+   y="16.250677"
+   
+   >192.0.2.88</tspan><tspan
+   font-size="2.86847px"
+   x="11.005307"
+   y="84.96907"
+   
+   >Source 2</tspan><tspan
+   font-size="2.86847px"
+   x="12.057905"
+   y="87.837547"
+   
+   >192.0.2.12</tspan></text>
+    <path
+       d="m 17.320674,89.246088 c 0,-0.404641 -0.240181,-0.73266 -0.536457,-0.73266 H 10.81373 c -0.296281,0 -0.536467,0.328019 -0.536467,0.73266 v 6.405145 c 0,0.404641 0.240186,0.732667 0.536467,0.732667 h 5.970487 c 0.296276,0 0.536457,-0.328026 0.536457,-0.732667 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 16.087544,89.096418 v 0.830939 h -1.423617 l -0.758221,1.864551 -0.773709,-1.864551 h -1.408149 v -0.830939 l -0.912969,1.053877 0.912969,1.05387 v -0.709337 h 1.005823 l 0.866553,2.046946 -0.866553,2.06721 h -1.005823 v -0.77013 l -0.912969,1.053877 0.912969,1.053877 v -0.79041 h 1.408149 l 0.773709,-1.90508 0.758221,1.90508 h 1.423617 v 0.749866 l 0.912974,-1.013333 -0.912974,-1.053877 v 0.77013 h -0.990339 l -0.882016,-2.06721 0.866537,-2.046946 h 1.005818 v 0.68908 l 0.912974,-1.033613 z"
+       stroke="#000000"
+       stroke-width="0.218253"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 17.320674,92.448638 H 37.794548"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="19.34832"
+       y="126.11659"
+       width="16.221159"
+       height="8.4534235"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="26.788706"
+       y="112.65598"
+       
+       transform="scale(0.85569064,1.1686467)">DATA 2</text>
+    <rect
+       x="19.34832"
+       y="134.57001"
+       width="16.221159"
+       height="8.4534101"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="27.116095"
+       y="118.64234"
+       
+       transform="scale(0.85569064,1.1686467)">IP <tspan
+   font-size="1.99545px"
+   x="30.826385"
+   y="118.64234"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.99545px"
+   x="30.790007"
+   y="121.26137"
+   
+   >192.0.2.89</tspan><tspan
+   font-size="2.86847px"
+   x="200.65437"
+   y="84.96907"
+   
+   >Destination 2</tspan><tspan
+   font-size="2.86847px"
+   x="204.45445"
+   y="87.837547"
+   
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 181.88005,89.246081 c 0,-0.404634 -0.24018,-0.732653 -0.53646,-0.732653 h -5.86377 c -0.29628,0 -0.53646,0.328019 -0.53646,0.732653 v 6.405145 c 0,0.404618 0.24018,0.732644 0.53646,0.732644 h 5.86377 c 0.29628,0 0.53646,-0.328026 0.53646,-0.732644 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 180.75364,89.096418 v 0.830939 h -1.42362 l -0.75823,1.864551 -0.77371,-1.864551 h -1.40815 v -0.830939 l -0.91298,1.053877 0.91298,1.05387 v -0.709337 h 1.00583 l 0.86654,2.046946 -0.86654,2.06721 h -1.00583 v -0.77013 l -0.91298,1.053877 0.91298,1.053877 v -0.79041 h 1.40815 l 0.77371,-1.90508 0.75823,1.90508 h 1.42362 v 0.749866 l 0.91297,-1.013333 -0.91297,-1.053877 v 0.77013 h -0.99035 l -0.88202,-2.06721 0.86655,-2.046946 h 1.00582 v 0.68908 l 0.91297,-1.033613 z"
+       stroke="#000000"
+       stroke-width="0.218253"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 154.34677,92.448638 20.63928,0.0084"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="156.2677"
+       y="126.11659"
+       width="16.221159"
+       height="8.4534235"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="186.78099"
+       y="112.65598"
+       
+       transform="scale(0.85569064,1.1686467)">DATA 2</text>
+    <rect
+       x="156.2677"
+       y="134.57001"
+       width="16.221159"
+       height="8.4534101"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="187.10774"
+       y="118.64234"
+       
+       transform="scale(0.85569064,1.1686467)">IP <tspan
+   font-size="1.99545px"
+   x="190.81804"
+   y="118.64234"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.99545px"
+   x="190.78166"
+   y="121.26137"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="74.201447"
+       y="37.209885"
+       width="16.221159"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="89.665794"
+       y="35.082764"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS A<tspan
+   font-size="1.99545px"
+   x="97.231895"
+   y="35.082764"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="98.06852"
+   y="35.082764"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="93.831512"
+   y="37.57708"
+   
+   >1000</tspan></text>
+    <rect
+       x="46.774883"
+       y="125.97084"
+       width="16.221159"
+       height="8.4534235"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="57.808392"
+       y="111.03468"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS S<tspan
+   font-size="1.99545px"
+   x="65.119858"
+   y="111.03468"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="65.95649"
+   y="111.03468"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="62.428066"
+   y="113.52899"
+   
+   >103</tspan></text>
+    <rect
+       x="46.774883"
+       y="109.06399"
+       width="16.221159"
+       height="8.4533949"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="58.845154"
+       y="98.06424"
+       
+       transform="scale(0.85569064,1.1686467)">DATA 2</text>
+    <rect
+       x="46.774883"
+       y="117.51743"
+       width="16.221159"
+       height="8.4534235"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="59.172539"
+       y="104.05059"
+       
+       transform="scale(0.85569064,1.1686467)">IP <tspan
+   font-size="1.99545px"
+   x="62.882828"
+   y="104.05059"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.99545px"
+   x="62.846451"
+   y="106.66962"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="74.308167"
+       y="125.97084"
+       width="16.221159"
+       height="8.4534235"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="89.813461"
+       y="111.03468"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS A<tspan
+   font-size="1.99545px"
+   x="97.379539"
+   y="111.03468"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="98.216187"
+   y="111.03468"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="93.979179"
+   y="113.52899"
+   
+   >1000</tspan></text>
+    <rect
+       x="101.73473"
+       y="125.97084"
+       width="16.327875"
+       height="8.4534235"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="121.93875"
+       y="111.03468"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS A<tspan
+   font-size="1.99545px"
+   x="129.50484"
+   y="111.03468"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="130.34148"
+   y="111.03468"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="126.10445"
+   y="113.52899"
+   
+   >1000</tspan></text>
+    <rect
+       x="101.62801"
+       y="37.209885"
+       width="16.327875"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="121.82027"
+       y="35.082764"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS A<tspan
+   font-size="1.99545px"
+   x="129.38635"
+   y="35.082764"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="130.22299"
+   y="35.082764"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="125.98598"
+   y="37.57708"
+   
+   >1000</tspan></text>
+    <path
+       d="m 44.74724,89.246081 c 0,-0.404634 -0.240181,-0.732653 -0.536457,-0.732653 h -5.863752 c -0.296281,0 -0.536462,0.328019 -0.536462,0.732653 v 6.405108 c 0,0.404648 0.240181,0.732652 0.536462,0.732652 h 5.863752 c 0.296276,0 0.536457,-0.328004 0.536457,-0.732652 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 43.605085,89.096418 v 0.830939 h -1.448162 l -0.771309,1.864551 -0.787043,-1.864551 h -1.432437 v -0.830939 l -0.928715,1.053877 0.928715,1.05387 v -0.709337 h 1.023159 l 0.881505,2.046946 -0.881505,2.06721 h -1.023159 v -0.77013 l -0.928715,1.053877 0.928715,1.053877 v -0.79041 h 1.432437 l 0.787043,-1.90508 0.771309,1.90508 h 1.448162 v 0.749866 l 0.928714,-1.013333 -0.928714,-1.053877 v 0.77013 h -1.00742 l -0.897229,-2.06721 0.881489,-2.046946 h 1.02316 v 0.68908 l 0.928714,-1.033613 z"
+       stroke="#000000"
+       stroke-width="0.218253"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="M 44.74724,92.507818 65.11194,73.501311"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="42.937405"
+       y="84.96907"
+       
+       transform="scale(0.85569064,1.1686467)">Ingress 2<tspan
+   font-size="2.86847px"
+   x="44.118885"
+   y="87.837547"
+   
+   >192.0.2.23</tspan></text>
+    <path
+       d="m 154.34677,89.246088 c 0,-0.404641 -0.24018,-0.73266 -0.53646,-0.73266 h -5.97049 c -0.29628,0 -0.53646,0.328019 -0.53646,0.73266 v 6.405145 c 0,0.404641 0.24018,0.732667 0.53646,0.732667 h 5.97049 c 0.29628,0 0.53646,-0.328026 0.53646,-0.732667 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 153.20461,89.096418 v 0.830939 h -1.44816 l -0.7713,1.864551 -0.78705,-1.864551 h -1.43244 v -0.830939 l -0.92871,1.053877 0.92871,1.05387 v -0.709337 h 1.02317 l 0.8815,2.046946 -0.8815,2.06721 h -1.02317 v -0.77013 l -0.92871,1.053877 0.92871,1.053877 v -0.79041 h 1.43244 l 0.78705,-1.90508 0.7713,1.90508 h 1.44816 v 0.749866 l 0.92872,-1.013333 -0.92872,-1.053877 v 0.77013 h -1.00741 l -0.89724,-2.06721 0.8815,-2.046946 h 1.02315 v 0.68908 l 0.92872,-1.033613 z"
+       stroke="#000000"
+       stroke-width="0.218253"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="171.18527"
+       y="84.96907"
+       
+       transform="scale(0.85569064,1.1686467)">Egress 2<tspan
+   font-size="2.86847px"
+   x="171.94769"
+   y="87.837547"
+   
+   >192.0.2.78</tspan></text>
+    <rect
+       x="46.774883"
+       y="134.57001"
+       width="16.221159"
+       height="8.4534101"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="57.863018"
+       y="118.26819"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS F<tspan
+   font-size="1.99545px"
+   x="65.065361"
+   y="118.26819"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="65.901993"
+   y="118.26819"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="61.264858"
+   y="120.7625"
+   
+   >10006</tspan></text>
+    <path
+       d="m 126.9202,73.50131 20.43012,18.990621"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <rect
+       x="129.16129"
+       y="125.97084"
+       width="16.221159"
+       height="8.4534235"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="154.10545"
+       y="111.03468"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS S<tspan
+   font-size="1.99545px"
+   x="161.41692"
+   y="111.03468"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="162.25356"
+   y="111.03468"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="158.72513"
+   y="113.52899"
+   
+   >105</tspan></text>
+    <rect
+       x="129.16129"
+       y="134.57001"
+       width="16.221159"
+       height="8.4534101"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.99545px"
+       
+       x="154.15907"
+       y="118.26819"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS F<tspan
+   font-size="1.99545px"
+   x="161.3614"
+   y="118.26819"
+   
+   >-</tspan><tspan
+   font-size="1.99545px"
+   x="162.19804"
+   y="118.26819"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="157.5609"
+   y="120.7625"
+   
+   >10011</tspan></text>
+    <rect
+       x="129.16129"
+       y="109.06399"
+       width="16.221159"
+       height="8.4533949"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="155.14185"
+       y="98.06424"
+       
+       transform="scale(0.85569064,1.1686467)">DATA 2</text>
+    <rect
+       x="129.16129"
+       y="117.51743"
+       width="16.221159"
+       height="8.4534235"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="155.4686"
+       y="104.05059"
+       
+       transform="scale(0.85569064,1.1686467)">IP <tspan
+   font-size="1.99545px"
+   x="159.17888"
+   y="104.05059"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.99545px"
+   x="159.1425"
+   y="106.66962"
+   
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 36.196449,75.541789 c -0.184197,0 -0.333495,-0.815611 -0.333495,-1.821856 0,-1.006104 0.149298,-1.821858 0.333495,-1.821858 0.184192,0 0.333489,0.815754 0.333489,1.821858 0,1.006245 -0.149297,1.821856 -0.333489,1.821856 h -18.00869 c -0.184192,0 -0.333495,-0.815611 -0.333495,-1.821856 0,-1.006104 0.149303,-1.821858 0.333495,-1.821858 h 18.00869"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="28.555683"
+       y="60.400066"
+       
+       transform="scale(0.85569064,1.1686467)">App-1</text>
+    <path
+       d="m 36.303164,94.489122 c -0.184197,0 -0.333495,-0.815759 -0.333495,-1.821863 0,-1.006245 0.149298,-1.821856 0.333495,-1.821856 0.184197,0 0.333494,0.815611 0.333494,1.821856 0,1.006104 -0.149297,1.821863 -0.333494,1.821863 H 18.294479 c -0.184197,0 -0.333495,-0.815759 -0.333495,-1.821863 0,-1.006245 0.149298,-1.821856 0.333495,-1.821856 h 18.008685"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="28.297146"
+       y="83.721924"
+       
+       transform="scale(0.85569064,1.1686467)">App-2</text>
+    <path
+       d="m 173.4365,75.39604 c -0.18462,0 -0.33402,-0.815604 -0.33402,-1.821856 0,-1.006248 0.1494,-1.821859 0.33402,-1.821859 0.18357,0 0.33297,0.815611 0.33297,1.821859 0,1.006252 -0.1494,1.821856 -0.33297,1.821856 h -18.11646 c -0.18356,0 -0.33296,-0.815604 -0.33296,-1.821856 0,-1.006248 0.1494,-1.821859 0.33296,-1.821859 h 18.11646"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="188.70784"
+       y="60.400066"
+       
+       transform="scale(0.85569064,1.1686467)">App-1</text>
+    <path
+       d="m 173.476,94.78062 c -0.22091,0 -0.4002,-0.978847 -0.4002,-2.186232 0,-1.207379 0.17929,-2.186233 0.4002,-2.186233 0.2209,0 0.40019,0.978854 0.40019,2.186233 0,1.207385 -0.17929,2.186232 -0.40019,2.186232 h -17.98201 c -0.22091,0 -0.4002,-0.978847 -0.4002,-2.186232 0,-1.207379 0.17929,-2.186233 0.4002,-2.186233 H 173.476"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="188.91487"
+       y="83.721924"
+       
+       transform="scale(0.85569064,1.1686467)">App-2</text>
+    <path
+       d="m 63.342873,77.582273 c -0.397845,0 -0.720347,-1.761807 -0.720347,-3.935214 0,-2.173405 0.322502,-3.935215 0.720347,-3.935215 0.397846,0 0.720348,1.76181 0.720348,3.935215 0,2.173407 -0.322502,3.935214 -0.720348,3.935214 H 46.107892 c -0.397842,0 -0.720347,-1.761807 -0.720347,-3.935214 0,-2.173405 0.322505,-3.935215 0.720347,-3.935215 h 17.234981"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="61.282227"
+       y="58.903477"
+       
+       transform="scale(0.85569064,1.1686467)">DN<tspan
+   font-size="2.86847px"
+   x="64.956146"
+   y="58.903477"
+   
+   >-1</tspan></text>
+    <path
+       d="m 65.403174,79.114531 c -0.330079,0.301115 -1.312313,-0.916322 -2.193912,-2.718945 -0.881705,-1.802763 -1.328854,-3.50817 -0.998881,-3.80914 0.329972,-0.301118 1.312206,0.916321 2.193804,2.718942 0.881706,1.802763 1.328962,3.508168 0.998989,3.809143 L 48.143329,94.859615 C 47.813356,95.16073 46.83112,93.943293 45.949524,92.14067 45.06782,90.337907 44.620561,88.632502 44.950642,88.331527 L 62.210381,72.586446"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       transform="matrix(0.71155573,-0.64911206,0.47528407,0.97179651,0,0)"
+       
+       x="6.9895267"
+       y="102.05008"
+       >DN<tspan
+   font-size="2.86847px"
+   x="10.638352"
+   y="102.08765"
+   
+   >-</tspan><tspan
+   font-size="2.86847px"
+   x="11.519117"
+   y="102.07605"
+   
+   >2</tspan></text>
+    <path
+       d="m 145.62256,77.436523 c -0.39806,0 -0.72035,-1.761806 -0.72035,-3.935213 0,-2.173404 0.32229,-3.935215 0.72035,-3.935215 0.39806,0 0.72035,1.761811 0.72035,3.935215 0,2.173407 -0.32229,3.935213 -0.72035,3.935213 h -17.23498 c -0.39806,0 -0.72035,-1.761806 -0.72035,-3.935213 0,-2.173404 0.32229,-3.935215 0.72035,-3.935215 h 17.23498"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="157.40044"
+       y="58.903477"
+       
+       transform="scale(0.85569064,1.1686467)">DN<tspan
+   font-size="2.86847px"
+   x="161.07437"
+   y="58.903477"
+   
+   >-1</tspan></text>
+    <path
+       d="m 144.56819,94.63706 c -0.33297,-0.294852 0.0971,-2.008422 0.96046,-3.827367 0.86441,-1.818937 1.83448,-3.05445 2.16744,-2.759606 0.33296,0.294852 -0.0971,2.008421 -0.96153,3.827366 -0.86335,1.818938 -1.83341,3.054458 -2.16637,2.759607 L 127.15285,79.215241 c -0.33296,-0.294851 0.0971,-2.008413 0.96046,-3.827358 0.86335,-1.819092 1.83342,-3.054603 2.16638,-2.759754 l 17.4164,15.421958"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       transform="matrix(0.71797679,0.63578712,-0.46552747,0.980566,0,0)"
+       
+       x="174.56789"
+       y="-20.541878"
+       >DN<tspan
+   font-size="2.86847px"
+   x="178.24002"
+   y="-20.544647"
+   
+   >-</tspan><tspan
+   font-size="2.86847px"
+   x="179.0582"
+   y="-20.629225"
+   
+   >2</tspan></text>
+    <path
+       d="m 67.051329,41.509472 c 0,-1.972126 1.170591,-3.570843 2.614594,-3.570843 1.444004,0 2.614595,1.598717 2.614595,3.570843 0,1.972125 -1.170591,3.570842 -2.614595,3.570842 -1.444003,0 -2.614594,-1.598717 -2.614594,-3.570842 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.23806px"
+       
+       x="79.795288"
+       y="37.452362"
+       
+       transform="scale(0.85569064,1.1686467)">R</text>
+    <path
+       d="m 119.66337,41.509472 c 0,-1.972126 1.1707,-3.570843 2.6146,-3.570843 1.44389,0 2.61459,1.598717 2.61459,3.570843 0,1.972125 -1.1707,3.570842 -2.61459,3.570842 -1.4439,0 -2.6146,-1.598717 -2.6146,-3.570842 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.23806px"
+       
+       x="141.53784"
+       y="37.452362"
+       
+       transform="scale(0.85569064,1.1686467)">E</text>
+    <path
+       d="m 67.051329,130.9263 c 0,-2.0128 1.170591,-3.64373 2.614594,-3.64373 1.444004,0 2.614595,1.63093 2.614595,3.64373 0,2.01278 -1.170591,3.64371 -2.614595,3.64371 -1.444003,0 -2.614594,-1.63093 -2.614594,-3.64371 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.23806px"
+       
+       x="79.795288"
+       y="114.02785"
+       
+       transform="scale(0.85569064,1.1686467)">R</text>
+    <path
+       d="m 119.66337,130.9263 c 0,-2.0128 1.1707,-3.64373 2.6146,-3.64373 1.44389,0 2.61459,1.63093 2.61459,3.64373 0,2.01278 -1.1707,3.64371 -2.61459,3.64371 -1.4439,0 -2.6146,-1.63093 -2.6146,-3.64371 z"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="5.23806px"
+       
+       x="141.53784"
+       y="114.02785"
+       
+       transform="scale(0.85569064,1.1686467)">E</text>
+    <rect
+       x="74.201447"
+       y="20.303036"
+       width="8.1105795"
+       height="8.4534101"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="89.46962"
+       y="19.368572"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="89.033112"
+   y="21.114594"
+   
+   >S</tspan><tspan
+   font-size="1.49659px"
+   x="89.869751"
+   y="21.114594"
+   
+   >-</tspan><tspan
+   font-size="1.49659px"
+   x="90.488136"
+   y="21.114594"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="89.668953"
+   y="23.484194"
+   
+   >101</tspan></text>
+    <rect
+       x="74.201447"
+       y="11.849612"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.6213px"
+       
+       x="90.670753"
+       y="12.509203"
+       
+       transform="scale(0.85569064,1.1686467)">IP<tspan
+   font-size="1.6213px"
+   x="88.869438"
+   y="14.37994"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.6213px"
+   x="88.869438"
+   y="16.250677"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="74.201447"
+       y="3.396188"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.74602px"
+       
+       x="89.014908"
+       y="6.1486969"
+       
+       transform="scale(0.85569064,1.1686467)">DATA <tspan
+   font-size="1.74602px"
+   x="90.906418"
+   y="8.2688656"
+   
+   >1</tspan></text>
+    <rect
+       x="82.312027"
+       y="20.303036"
+       width="8.1105795"
+       height="8.4534101"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="98.955879"
+       y="19.368572"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="98.519371"
+   y="21.114594"
+   
+   >S</tspan><tspan
+   font-size="1.49659px"
+   x="99.35601"
+   y="21.114594"
+   
+   >-</tspan><tspan
+   font-size="1.49659px"
+   x="99.974388"
+   y="21.114594"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="99.15522"
+   y="23.484194"
+   
+   >104</tspan></text>
+    <rect
+       x="82.312027"
+       y="11.849612"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.6213px"
+       
+       x="100.15701"
+       y="12.509203"
+       
+       transform="scale(0.85569064,1.1686467)">IP<tspan
+   font-size="1.6213px"
+   x="98.35569"
+   y="14.37994"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.6213px"
+   x="98.35569"
+   y="16.250677"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="82.312027"
+       y="3.396188"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.74602px"
+       
+       x="98.50116"
+       y="6.1486969"
+       
+       transform="scale(0.85569064,1.1686467)">DATA <tspan
+   font-size="1.74602px"
+   x="100.39269"
+   y="8.2688656"
+   
+   >2</tspan></text>
+    <rect
+       x="74.308167"
+       y="108.91824"
+       width="8.1105795"
+       height="8.5991583"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="89.617279"
+       y="95.320496"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="89.180779"
+   y="97.066505"
+   
+   >S</tspan><tspan
+   font-size="1.49659px"
+   x="90.01741"
+   y="97.066505"
+   
+   >-</tspan><tspan
+   font-size="1.49659px"
+   x="90.635796"
+   y="97.066505"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="89.81662"
+   y="99.436104"
+   
+   >101</tspan></text>
+    <rect
+       x="82.418739"
+       y="108.91824"
+       width="8.1105795"
+       height="8.5991583"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="99.103539"
+       y="95.320496"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="98.66703"
+   y="97.066505"
+   
+   >S</tspan><tspan
+   font-size="1.49659px"
+   x="99.503662"
+   y="97.066505"
+   
+   >-</tspan><tspan
+   font-size="1.49659px"
+   x="100.12206"
+   y="97.066505"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="99.302879"
+   y="99.436104"
+   
+   >104</tspan></text>
+    <rect
+       x="74.308167"
+       y="100.46481"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.6213px"
+       
+       x="90.818298"
+       y="88.336403"
+       
+       transform="scale(0.85569064,1.1686467)">IP<tspan
+   font-size="1.6213px"
+   x="89.016991"
+   y="90.207146"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.6213px"
+   x="89.016991"
+   y="92.077873"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="82.418739"
+       y="100.46481"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.6213px"
+       
+       x="100.30455"
+       y="88.336403"
+       
+       transform="scale(0.85569064,1.1686467)">IP<tspan
+   font-size="1.6213px"
+   x="98.503242"
+   y="90.207146"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.6213px"
+   x="98.503242"
+   y="92.077873"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="74.308167"
+       y="92.011398"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.74602px"
+       
+       x="89.162567"
+       y="81.975891"
+       
+       transform="scale(0.85569064,1.1686467)">DATA <tspan
+   font-size="1.74602px"
+   x="91.0541"
+   y="84.096062"
+   
+   >1</tspan></text>
+    <rect
+       x="82.418739"
+       y="92.011398"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.74602px"
+       
+       x="98.648827"
+       y="81.975891"
+       
+       transform="scale(0.85569064,1.1686467)">DATA <tspan
+   font-size="1.74602px"
+   x="100.54035"
+   y="84.096062"
+   
+   >2</tspan></text>
+    <rect
+       x="101.62801"
+       y="20.303036"
+       width="8.2172976"
+       height="8.4534101"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="121.62447"
+       y="19.368572"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="121.18797"
+   y="21.114594"
+   
+   >S</tspan><tspan
+   font-size="1.49659px"
+   x="122.0246"
+   y="21.114594"
+   
+   >-</tspan><tspan
+   font-size="1.49659px"
+   x="122.64299"
+   y="21.114594"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="121.82381"
+   y="23.484194"
+   
+   >101</tspan></text>
+    <rect
+       x="109.84531"
+       y="20.303036"
+       width="8.1105795"
+       height="8.4534101"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="131.11035"
+       y="19.368572"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="130.67384"
+   y="21.114594"
+   
+   >S</tspan><tspan
+   font-size="1.49659px"
+   x="131.51048"
+   y="21.114594"
+   
+   >-</tspan><tspan
+   font-size="1.49659px"
+   x="132.12888"
+   y="21.114594"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="131.30969"
+   y="23.484194"
+   
+   >104</tspan></text>
+    <rect
+       x="101.62801"
+       y="11.849612"
+       width="8.2172976"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.6213px"
+       
+       x="122.82548"
+       y="12.509203"
+       
+       transform="scale(0.85569064,1.1686467)">IP<tspan
+   font-size="1.6213px"
+   x="121.02419"
+   y="14.37994"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.6213px"
+   x="121.02419"
+   y="16.250677"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="109.84531"
+       y="11.849612"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.6213px"
+       
+       x="132.31137"
+       y="12.509203"
+       
+       transform="scale(0.85569064,1.1686467)">IP<tspan
+   font-size="1.6213px"
+   x="130.51007"
+   y="14.37994"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.6213px"
+   x="130.51007"
+   y="16.250677"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="101.62801"
+       y="3.396188"
+       width="8.2172976"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.74602px"
+       
+       x="121.16926"
+       y="6.1486969"
+       
+       transform="scale(0.85569064,1.1686467)">DATA <tspan
+   font-size="1.74602px"
+   x="123.06077"
+   y="8.2688656"
+   
+   >1</tspan></text>
+    <rect
+       x="109.84531"
+       y="3.396188"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.74602px"
+       
+       x="130.65639"
+       y="6.1486969"
+       
+       transform="scale(0.85569064,1.1686467)">DATA <tspan
+   font-size="1.74602px"
+   x="132.5479"
+   y="8.2688656"
+   
+   >2</tspan></text>
+    <rect
+       x="101.73473"
+       y="108.91824"
+       width="8.1105795"
+       height="8.5991583"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="121.7417"
+       y="95.320496"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="121.3052"
+   y="97.066505"
+   
+   >S</tspan><tspan
+   font-size="1.49659px"
+   x="122.14184"
+   y="97.066505"
+   
+   >-</tspan><tspan
+   font-size="1.49659px"
+   x="122.76022"
+   y="97.066505"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="121.94105"
+   y="99.436104"
+   
+   >101</tspan></text>
+    <rect
+       x="109.84531"
+       y="108.91824"
+       width="8.2172976"
+       height="8.5991583"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="131.22884"
+       y="95.320496"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="130.79233"
+   y="97.066505"
+   
+   >S</tspan><tspan
+   font-size="1.49659px"
+   x="131.62897"
+   y="97.066505"
+   
+   >-</tspan><tspan
+   font-size="1.49659px"
+   x="132.24736"
+   y="97.066505"
+   
+   >label</tspan><tspan
+   font-size="1.99545px"
+   x="131.42818"
+   y="99.436104"
+   
+   >104</tspan></text>
+    <rect
+       x="101.73473"
+       y="100.46481"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.6213px"
+       
+       x="122.94396"
+       y="88.336403"
+       
+       transform="scale(0.85569064,1.1686467)">IP<tspan
+   font-size="1.6213px"
+   x="121.14264"
+   y="90.207146"
+   
+   >192.0.2.1</tspan><tspan
+   font-size="1.6213px"
+   x="121.14264"
+   y="92.077873"
+   
+   >192.0.2.88</tspan></text>
+    <rect
+       x="109.84531"
+       y="100.46481"
+       width="8.2172976"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.6213px"
+       
+       x="132.42984"
+       y="88.336403"
+       
+       transform="scale(0.85569064,1.1686467)">IP<tspan
+   font-size="1.6213px"
+   x="130.62852"
+   y="90.207146"
+   
+   >192.0.2.12</tspan><tspan
+   font-size="1.6213px"
+   x="130.62852"
+   y="92.077873"
+   
+   >192.0.2.89</tspan></text>
+    <rect
+       x="101.73473"
+       y="92.011398"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.74602px"
+       
+       x="121.28773"
+       y="81.975891"
+       
+       transform="scale(0.85569064,1.1686467)">DATA <tspan
+   font-size="1.74602px"
+   x="123.17925"
+   y="84.096062"
+   
+   >1</tspan></text>
+    <rect
+       x="109.84531"
+       y="92.011398"
+       width="8.2172976"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.74602px"
+       
+       x="130.77362"
+       y="81.975891"
+       
+       transform="scale(0.85569064,1.1686467)">DATA <tspan
+   font-size="1.74602px"
+   x="132.66513"
+   y="84.096062"
+   
+   >2</tspan></text>
+    <rect
+       x="74.201447"
+       y="28.756462"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="89.470367"
+       y="26.851521"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="89.070236"
+   y="28.597538"
+   
+   >F-</tspan><tspan
+   font-size="1.49659px"
+   x="90.452507"
+   y="28.597538"
+   
+   >label</tspan><tspan
+   font-size="1.74602px"
+   x="88.869438"
+   y="30.717709"
+   
+   >20004</tspan></text>
+    <rect
+       x="82.312027"
+       y="28.756462"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="98.956627"
+       y="26.851521"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="98.556488"
+   y="28.597538"
+   
+   >F-</tspan><tspan
+   font-size="1.49659px"
+   x="99.938759"
+   y="28.597538"
+   
+   >label</tspan><tspan
+   font-size="1.74602px"
+   x="98.355698"
+   y="30.717709"
+   
+   >20005</tspan></text>
+    <rect
+       x="74.308167"
+       y="117.51743"
+       width="8.1105795"
+       height="8.4534235"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="89.617905"
+       y="102.67872"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="89.217781"
+   y="104.42474"
+   
+   >F-</tspan><tspan
+   font-size="1.49659px"
+   x="90.600044"
+   y="104.42474"
+   
+   >label</tspan><tspan
+   font-size="1.74602px"
+   x="89.016991"
+   y="106.54491"
+   
+   >20004</tspan></text>
+    <rect
+       x="82.418739"
+       y="117.51743"
+       width="8.1105795"
+       height="8.4534235"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="99.104164"
+       y="102.67872"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="98.704033"
+   y="104.42474"
+   
+   >F-</tspan><tspan
+   font-size="1.49659px"
+   x="100.0863"
+   y="104.42474"
+   
+   >label</tspan><tspan
+   font-size="1.74602px"
+   x="98.503242"
+   y="106.54491"
+   
+   >20005</tspan></text>
+    <rect
+       x="101.62801"
+       y="28.756462"
+       width="8.2172976"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="121.62572"
+       y="26.851521"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="121.22559"
+   y="28.597538"
+   
+   >F-</tspan><tspan
+   font-size="1.49659px"
+   x="122.60785"
+   y="28.597538"
+   
+   >label</tspan><tspan
+   font-size="1.74602px"
+   x="121.0248"
+   y="30.717709"
+   
+   >20004</tspan></text>
+    <rect
+       x="109.84531"
+       y="28.756462"
+       width="8.1105795"
+       height="8.4534388"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="131.1116"
+       y="26.851521"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="130.71147"
+   y="28.597538"
+   
+   >F-</tspan><tspan
+   font-size="1.49659px"
+   x="132.09373"
+   y="28.597538"
+   
+   >label</tspan><tspan
+   font-size="1.74602px"
+   x="130.51068"
+   y="30.717709"
+   
+   >20005</tspan></text>
+    <rect
+       x="101.73473"
+       y="117.51743"
+       width="8.1105795"
+       height="8.4534235"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="121.74295"
+       y="102.67872"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="121.34281"
+   y="104.42474"
+   
+   >F-</tspan><tspan
+   font-size="1.49659px"
+   x="122.72508"
+   y="104.42474"
+   
+   >label</tspan><tspan
+   font-size="1.74602px"
+   x="121.14202"
+   y="106.54491"
+   
+   >20004</tspan></text>
+    <rect
+       x="109.84531"
+       y="117.51743"
+       width="8.2172976"
+       height="8.4534235"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+        />
+    <text
+       font-size="1.49659px"
+       
+       x="131.22884"
+       y="102.67872"
+       
+       transform="scale(0.85569064,1.1686467)">MPLS<tspan
+   font-size="1.49659px"
+   x="130.82869"
+   y="104.42474"
+   
+   >F-</tspan><tspan
+   font-size="1.49659px"
+   x="132.21097"
+   y="104.42474"
+   
+   >label</tspan><tspan
+   font-size="1.74602px"
+   x="130.6279"
+   y="106.54491"
+   
+   >20005</tspan><tspan
+   font-size="4.11562px"
+   x="161.91939"
+   y="41.443268"
+   
+   >Note: S and A labels in this diagram</tspan><tspan
+   font-size="4.11562px"
+   x="161.91939"
+   y="46.307182"
+   
+   >include d-CWs of their own.</tspan></text>
+    <path
+       d="m 71.133298,73.209813 c -0.397845,0 -0.720348,-1.761811 -0.720348,-3.935215 0,-2.173405 0.322503,-3.935215 0.720348,-3.935215 0.397845,0 0.720347,1.76181 0.720347,3.935215 0,2.173404 -0.322502,3.935215 -0.720347,3.935215 h -5.17583 c -0.397845,0 -0.720348,-1.761811 -0.720348,-3.935215 0,-2.173405 0.322503,-3.935215 0.720348,-3.935215 h 5.17583"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="77.687592"
+       y="58.903477"
+       
+       transform="scale(0.85569064,1.1686467)">DN<tspan
+   font-size="2.86847px"
+   x="81.361519"
+   y="58.903477"
+   
+   >-1</tspan></text>
+    <path
+       d="m 70.919862,81.51749 c -0.397846,0 -0.720348,-1.761814 -0.720348,-3.935217 0,-2.173404 0.322502,-3.935214 0.720348,-3.935214 0.397845,0 0.720347,1.76181 0.720347,3.935214 0,2.173403 -0.322502,3.935217 -0.720347,3.935217 H 65.85075 c -0.397845,0 -0.720348,-1.761814 -0.720348,-3.935217 0,-2.173404 0.322503,-3.935214 0.720348,-3.935214 h 5.069112"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="77.773277"
+       y="68.75602"
+       
+       transform="scale(0.85569064,1.1686467)">DN<tspan
+   font-size="2.86847px"
+   x="81.447197"
+   y="68.75602"
+   
+   >-2</tspan></text>
+    <path
+       d="m 117.44897,81.371741 c -0.80999,0 -1.46737,-3.588916 -1.46737,-8.01618 0,-4.427262 0.65738,-8.016178 1.46737,-8.016178 0.80999,0 1.46738,3.588916 1.46738,8.016178 0,4.427264 -0.65739,8.01618 -1.46738,8.01618 H 75.02851 c -0.810418,0 -1.467481,-3.588916 -1.467481,-8.01618 0,-4.427262 0.657063,-8.016178 1.467481,-8.016178 h 42.42046"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="103.25994"
+       y="64.01683"
+       
+       transform="scale(0.85569064,1.1686467)">Aggregated DN-1</text>
+    <path
+       d="m 126.09314,73.209813 c -0.39806,0 -0.72035,-1.761811 -0.72035,-3.935215 0,-2.173405 0.32229,-3.935215 0.72035,-3.935215 0.39806,0 0.72035,1.76181 0.72035,3.935215 0,2.173404 -0.32229,3.935215 -0.72035,3.935215 h -5.06911 c -0.39806,0 -0.72035,-1.761811 -0.72035,-3.935215 0,-2.173405 0.32229,-3.935215 0.72035,-3.935215 h 5.06911"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="142.22502"
+       y="59.028191"
+       
+       transform="scale(0.85569064,1.1686467)">DN<tspan
+   font-size="2.86847px"
+   x="145.89896"
+   y="59.028191"
+   
+   >-1</tspan></text>
+    <path
+       d="m 126.00029,81.51749 c -0.39058,0 -0.70753,-1.729162 -0.70753,-3.862339 0,-2.133037 0.31695,-3.862344 0.70753,-3.862344 0.38952,0 0.70648,1.729307 0.70648,3.862344 0,2.133177 -0.31696,3.862339 -0.70648,3.862339 h -5.09685 c -0.38952,0 -0.70648,-1.729162 -0.70648,-3.862339 0,-2.133037 0.31696,-3.862344 0.70648,-3.862344 h 5.09685"
+       stroke="#000000"
+       stroke-width="0.291003"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="142.07536"
+       y="68.63131"
+       
+       transform="scale(0.85569064,1.1686467)">DN<tspan
+   font-size="2.86847px"
+   x="145.74927"
+   y="68.63131"
+   
+   >-2</tspan></text>
+    <path
+       d="m 61.021754,64.171644 c 0,-0.361165 0.214397,-0.65412 0.478951,-0.65412 h 13.875919 c 0.264448,0 0.478951,0.292955 0.478951,0.65412 v 20.116815 c 0,0.361312 -0.214503,0.654122 -0.478951,0.654122 H 61.500705 c -0.264554,0 -0.478951,-0.29281 -0.478951,-0.654122 z"
+       stroke="#000000"
+       stroke-width="0.582006"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.32804, 1.74602"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <path
+       d="m 115.55472,64.19992 c 0,-0.376906 0.22411,-0.682396 0.49944,-0.682396 h 14.47525 c 0.27534,0 0.49944,0.30549 0.49944,0.682396 v 20.060265 c 0,0.376911 -0.2241,0.682396 -0.49944,0.682396 h -14.47525 c -0.27533,0 -0.49944,-0.305485 -0.49944,-0.682396 z"
+       stroke="#000000"
+       stroke-width="0.582006"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.32804, 1.74602"
+       fill="none"
+       fill-rule="evenodd"
+        />
+    <text
+       font-size="2.86847px"
+       
+       x="73.046295"
+       y="78.359138"
+       
+       transform="scale(0.85569064,1.1686467)">aggregation<tspan
+   font-size="2.86847px"
+   x="135.51781"
+   y="78.359138"
+   
+   >disaggregation</tspan></text>
+  </g>
+</svg>
+</artwork>
+</artset>
+        </figure>
+        <figure anchor="example-detnet-json-forwarding-aggregation-c-4">
+          <name>Example C-4 DetNet JSON Relay Service Sub-Layer Aggregation</name>
+          <artwork name="" type="" align="left" alt=""><![CDATA[
+{
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "eth0",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth1",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth2",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth3",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth4",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      }
+    ]
+  },
+  "ietf-detnet:detnet": {
+    "traffic-profile": [
+      {
+        "profile-name": "pf-1",
+        "traffic-requirements": {
+          "min-bandwidth": "100000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 100000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "member-services": [
+          "ssl-1",
+          "ssl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-2",
+        "traffic-requirements": {
+          "min-bandwidth": "200000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 100000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "member-services": [
+          "asl-1"
+        ]
+      },
+      {
+        "profile-name": "pf-3",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 1,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "fsl-1",
+          "fsl-2",
+          "fsl-3",
+          "fsl-4"
+        ]
+      },
+      {
+        "profile-name": "pf-4",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 2,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "fsl-5",
+          "fsl-6"
+        ]
+      }
+    ],
+    "service-sub-layer": {
+      "service-sub-layer-list": [
+        {
+          "name": "ssl-1",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "none",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 100
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 101
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-3"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "ssl-2",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "none",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 103
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 104
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-4"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "asl-1",
+          "service-rank": 10,
+          "traffic-profile": "pf-2",
+          "service-protection": {
+            "service-protection-type": "replication",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-initiation",
+          "incoming-type": {
+            "forwarding-aggregation": {
+              "forwarding-sub-layer": [
+                "fsl-3",
+                "fsl-4"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 1000
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-5",
+                    "fsl-6"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "forwarding-sub-layer": {
+      "forwarding-sub-layer-list": [
+        {
+          "name": "fsl-1",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth0",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10000
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-2",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10006
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-2"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-3",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "service-aggregation": {
+              "aggregation-service-sub-layer": "asl-1",
+              "optional-forwarding-label": {
+                "mpls-label-stack": {
+                  "entry": [
+                    {
+                      "id": 0,
+                      "label": 20004
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "fsl-4",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-2"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "service-aggregation": {
+              "aggregation-service-sub-layer": "asl-1",
+              "optional-forwarding-label": {
+                "mpls-label-stack": {
+                  "entry": [
+                    {
+                      "id": 0,
+                      "label": 20005
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "fsl-5",
+          "traffic-profile": "pf-4",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "asl-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth2",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20000
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "fsl-6",
+          "traffic-profile": "pf-4",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "asl-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth3",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20001
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+]]></artwork>
+        </figure>
+        <figure anchor="example-detnet-json-forwarding-disaggregation-c-4">
+          <name>Example C-4 DetNet JSON Relay Service Sub-Layer Disaggregation</name>
+          <artwork name="" type="" align="left" alt=""><![CDATA[
+{
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "eth0",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth1",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth2",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth3",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth4",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      }
+    ]
+  },
+  "ietf-detnet:detnet": {
+    "traffic-profile": [
+      {
+        "profile-name": "pf-1",
+        "traffic-requirements": {
+          "min-bandwidth": "100000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 100000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "member-services": [
+          "ssl-1",
+          "ssl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-2",
+        "traffic-requirements": {
+          "min-bandwidth": "200000000",
+          "max-latency": 100000000,
+          "max-latency-variation": 100000000,
+          "max-loss": 2,
+          "max-consecutive-loss-tolerance": 5,
+          "max-misordering": 0
+        },
+        "member-services": [
+          "asl-1"
+        ]
+      },
+      {
+        "profile-name": "pf-3",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 1,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "fsl-3",
+          "fsl-4",
+          "fsl-5",
+          "fsl-6"
+        ]
+      },
+      {
+        "profile-name": "pf-4",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 2,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "fsl-1",
+          "fsl-2"
+        ]
+      }
+    ],
+    "service-sub-layer": {
+      "service-sub-layer-list": [
+        {
+          "name": "ssl-1",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "none",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 101
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 102
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-5"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "ssl-2",
+          "service-rank": 10,
+          "traffic-profile": "pf-1",
+          "service-protection": {
+            "service-protection-type": "none",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-relay",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 104
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "service-outgoing-list": [
+                {
+                  "service-outgoing-index": 0,
+                  "mpls-label-stack": {
+                    "entry": [
+                      {
+                        "id": 0,
+                        "label": 105
+                      }
+                    ]
+                  },
+                  "forwarding-sub-layer": [
+                    "fsl-6"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "asl-1",
+          "service-rank": 10,
+          "traffic-profile": "pf-2",
+          "service-protection": {
+            "service-protection-type": "elimination",
+            "sequence-number-length": "long-sn"
+          },
+          "service-operation-type": "service-termination",
+          "incoming-type": {
+            "service-id": {
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 1000
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-disaggregation": {
+              "forwarding-sub-layer": [
+                "fsl-3",
+                "fsl-4"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "forwarding-sub-layer": {
+      "forwarding-sub-layer-list": [
+        {
+          "name": "fsl-1",
+          "traffic-profile": "pf-4",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth0",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20002
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "asl-1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-2",
+          "traffic-profile": "pf-4",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20003
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "asl-1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-3",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth0",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20004
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-4",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20005
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-2"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fsl-5",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-1"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth2",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10005
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "fsl-6",
+          "traffic-profile": "pf-3",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "service-sub-layer": {
+              "service-sub-layer": [
+                "ssl-2"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth3",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10011
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+]]></artwork>
+        </figure>
+      </section>
+      <section numbered="true" toc="default">
+        <name>Example D-1 JSON Transit Forwarding Sub-Layer Aggregation/Disaggregation</name>
+        <t>
+                This illustrates the Transit node 1 aggregating the forwarding 
+                sub-layers of DetNet flow 1 and 2 into a forwarding sub-layer.
+                This also illustrates a Transit node 4 disaggregating a forwarding sub-layer
+                into DetNet flow 1 and 2 forwarding sub-layers.
+        </t>
+        <figure anchor="case-d1">
+        	<name>Case D-1 Example Service Aggregation/Disaggregation</name>
+          <artset>
+            <artwork align="left" type="ascii-art" name="" alt=""><![CDATA[
+        
+Please consult the PDF or HTML versions for the Case D-1 Diagram
+
+]]></artwork>
+	<artwork type="svg">
+<svg
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="210mm"
+   height="130mm"
+   viewBox="0 5 210 130"
+   version="1.1"
+   id="svg8">
+  <g
+     id="layer1">
+    <text
+       font-size="2.89029px"
+       
+       x="48.587341"
+       y="60.347198"
+       
+       transform="scale(0.8869959,1.1274009)">Ingress 1<tspan
+   font-size="2.89029px"
+   x="49.777794"
+   y="63.237488"
+   id="tspan15"
+   >192.0.2.2</tspan></text>
+    <path
+       d="m 51.4579,58.405437 c 0,-0.393324 -0.250864,-0.71218 -0.560316,-0.71218 h -6.124521 c -0.309456,0 -0.560317,0.318856 -0.560317,0.71218 v 6.22607 c 0,0.393335 0.250861,0.712187 0.560317,0.712187 h 6.124521 c 0.309452,0 0.560316,-0.318852 0.560316,-0.712187 z"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path19" />
+    <path
+       d="m 50.058471,58.11828 v 0.824896 H 48.571542 L 47.779587,60.794168 46.97147,58.943176 H 45.500705 V 58.11828 l -0.953588,1.046207 0.953588,1.046209 V 59.50652 h 1.050549 l 0.905086,2.032065 -0.905086,2.052182 h -1.050549 v -0.764528 l -0.953588,1.046207 0.953588,1.046208 v -0.784661 h 1.470765 l 0.808117,-1.891227 0.791955,1.891227 h 1.486929 v 0.744426 l 0.953575,-1.005973 -0.953575,-1.046207 v 0.764528 h -1.034385 l -0.92125,-2.052182 0.905085,-2.032065 h 1.05055 v 0.684059 l 0.953575,-1.026092 z"
+       stroke="#000000"
+       stroke-width="0.219914"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path21" />
+    <text
+       font-size="2.89029px"
+       
+       x="81.022888"
+       y="65.122452"
+       
+       transform="scale(0.8869959,1.1274009)">Transit 1<tspan
+   font-size="2.89029px"
+   x="82.084328"
+   y="68.012749"
+   id="tspan23"
+   >192.0.2.3</tspan></text>
+    <path
+       d="m 80.104164,58.405432 c 0,-0.393324 -0.25086,-0.712175 -0.560313,-0.712175 h -6.124544 c -0.309456,0 -0.560316,0.318851 -0.560316,0.712175 v 6.226091 c 0,0.393319 0.25086,0.712171 0.560316,0.712171 h 6.124544 c 0.309453,0 0.560313,-0.318852 0.560313,-0.712171 z"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path27" />
+    <path
+       d="m 78.704735,58.11828 v 0.824896 h -1.48693 l -0.791942,1.850992 -0.808115,-1.850992 H 74.146979 V 58.11828 l -0.953575,1.046207 0.953575,1.046209 V 59.50652 h 1.050549 l 0.90509,2.032065 -0.90509,2.052182 h -1.050549 v -0.764528 l -0.953575,1.046207 0.953575,1.046208 v -0.784661 h 1.470769 l 0.808115,-1.891227 0.791942,1.891227 h 1.48693 v 0.744426 l 0.953574,-1.005973 -0.953574,-1.046207 v 0.764528 H 77.67035 l -0.921242,-2.052182 0.905077,-2.032065 h 1.05055 v 0.684059 l 0.953574,-1.026092 z"
+       stroke="#000000"
+       stroke-width="0.219914"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path29" />
+    <text
+       font-size="2.89029px"
+       
+       x="145.63715"
+       y="65.122452"
+       
+       transform="scale(0.8869959,1.1274009)">Transit 4<tspan
+   font-size="2.89029px"
+   x="146.69861"
+   y="68.012749"
+   id="tspan31"
+   >192.0.2.6</tspan></text>
+    <path
+       d="m 137.39669,58.405437 c 0,-0.393324 -0.25087,-0.71218 -0.56032,-0.71218 h -6.12452 c -0.30945,0 -0.56032,0.318856 -0.56032,0.71218 v 6.22607 c 0,0.393335 0.25087,0.712187 0.56032,0.712187 h 6.12452 c 0.30945,0 0.56032,-0.318852 0.56032,-0.712187 z"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path35" />
+    <path
+       d="m 135.99726,58.259953 v 0.807712 h -1.48694 l -0.79195,1.812429 -0.80812,-1.812429 h -1.47076 v -0.807712 l -0.95358,1.024414 0.95358,1.02441 v -0.689505 h 1.05055 l 0.90509,1.989725 -0.90509,2.009426 h -1.05055 v -0.748609 l -0.95358,1.02442 0.95358,1.02442 v -0.768319 h 1.47076 l 0.80812,-1.851822 0.79195,1.851822 h 1.48694 v 0.728904 l 0.95357,-0.985005 -0.95357,-1.02442 v 0.748609 h -1.03439 l -0.92124,-2.009426 0.90507,-1.989725 h 1.05056 v 0.669811 l 0.95357,-1.004716 z"
+       stroke="#000000"
+       stroke-width="0.219914"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path37" />
+    <text
+       font-size="2.89029px"
+       
+       x="178.23834"
+       y="60.347198"
+       
+       transform="scale(0.8869959,1.1274009)">Egress 1<tspan
+   font-size="2.89029px"
+   x="179.00659"
+   y="63.237488"
+   id="tspan39"
+   >192.0.2.77</tspan></text>
+    <path
+       d="m 166.04294,58.405432 c 0,-0.393324 -0.25085,-0.712175 -0.5603,-0.712175 h -6.12455 c -0.30945,0 -0.56032,0.318851 -0.56032,0.712175 v 6.226091 c 0,0.393319 0.25087,0.712171 0.56032,0.712171 h 6.12455 c 0.30945,0 0.5603,-0.318852 0.5603,-0.712171 z"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path43" />
+    <path
+       d="m 164.64351,58.11828 v 0.824896 h -1.48692 l -0.79196,1.850992 -0.80811,-1.850992 h -1.47077 V 58.11828 l -0.95359,1.046207 0.95359,1.046209 V 59.50652 h 1.05055 l 0.90508,2.032065 -0.90508,2.052182 h -1.05055 v -0.764528 l -0.95359,1.046207 0.95359,1.046208 v -0.784661 h 1.47077 l 0.80811,-1.891227 0.79196,1.891227 h 1.48692 v 0.744426 l 0.95358,-1.005973 -0.95358,-1.046207 v 0.764528 h -1.03438 l -0.92125,-2.052182 0.90509,-2.032065 h 1.05054 v 0.684059 l 0.95358,-1.026092 z"
+       stroke="#000000"
+       stroke-width="0.219914"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path45" />
+    <text
+       font-size="2.89029px"
+       
+       x="113.33002"
+       y="76.809273"
+       
+       transform="scale(0.8869959,1.1274009)">Transit 3<tspan
+   font-size="2.89029px"
+   x="114.39145"
+   y="79.699562"
+   id="tspan47"
+   >192.0.2.5</tspan></text>
+    <path
+       d="m 108.75043,76.823112 c 0,-0.393324 -0.25086,-0.712175 -0.56032,-0.712175 h -6.12454 c -0.30946,0 -0.56031,0.318851 -0.56031,0.712175 v 6.226091 c 0,0.393319 0.25085,0.712171 0.56031,0.712171 h 6.12454 c 0.30946,0 0.56032,-0.318852 0.56032,-0.712171 z"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path51" />
+    <path
+       d="m 107.351,76.677632 v 0.807713 h -1.48694 l -0.79195,1.812429 -0.80811,-1.812429 h -1.47077 v -0.807713 l -0.95359,1.024415 0.95359,1.02441 v -0.689505 h 1.05055 l 0.90509,1.989725 -0.90509,2.009426 h -1.05055 v -0.74861 l -0.95359,1.024421 0.95359,1.02442 v -0.768319 h 1.47077 l 0.80811,-1.851822 0.79195,1.851822 h 1.48694 v 0.728904 l 0.95356,-0.985005 -0.95356,-1.024421 v 0.74861 h -1.03439 l -0.92125,-2.009426 0.90508,-1.989725 h 1.05056 v 0.669811 l 0.95356,-1.004716 z"
+       stroke="#000000"
+       stroke-width="0.219914"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path53" />
+    <text
+       font-size="2.89029px"
+       
+       x="113.33002"
+       y="43.885124"
+       
+       transform="scale(0.8869959,1.1274009)">Transit 2<tspan
+   font-size="2.89029px"
+   x="114.39145"
+   y="46.775417"
+   id="tspan55"
+   >192.0.2.4</tspan></text>
+    <path
+       d="m 108.75043,39.846075 c 0,-0.393324 -0.25086,-0.712177 -0.56032,-0.712177 h -6.12454 c -0.30946,0 -0.56031,0.318853 -0.56031,0.712177 v 6.226091 c 0,0.393318 0.25085,0.712171 0.56031,0.712171 h 6.12454 c 0.30946,0 0.56032,-0.318853 0.56032,-0.712171 z"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path59" />
+    <path
+       d="m 107.351,39.700594 v 0.807714 h -1.48694 l -0.79195,1.812428 -0.80811,-1.812428 h -1.47077 v -0.807714 l -0.95359,1.024421 0.95359,1.02442 V 41.05992 h 1.05055 l 0.90509,1.989731 -0.90509,2.009441 h -1.05055 v -0.74861 l -0.95359,1.024405 0.95359,1.02442 v -0.768314 h 1.47077 l 0.80811,-1.851827 0.79195,1.851827 h 1.48694 v 0.728915 l 0.95356,-0.985021 -0.95356,-1.024405 v 0.74861 h -1.03439 l -0.92125,-2.009441 0.90508,-1.989731 h 1.05056 v 0.669805 l 0.95356,-1.00471 z"
+       stroke="#000000"
+       stroke-width="0.219914"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path61" />
+    <path
+       d="M 51.4579,61.518467 H 72.842282"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path63" />
+    <path
+       d="M 80.104164,61.468594 101.48855,42.959109"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path65" />
+    <path
+       d="m 108.75043,42.959109 21.38438,18.509485"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path67" />
+    <path
+       d="m 137.39669,61.518467 h 21.38437"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path69" />
+    <path
+       d="m 108.75043,79.993527 21.38438,-18.47506"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path71" />
+    <path
+       d="m 80.104164,61.518467 21.384386,18.4752"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path73" />
+    <rect
+       x="53.687176"
+       y="25.958176"
+       width="16.942537"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect75" />
+    <text
+       font-size="2.01064px"
+       
+       x="63.677887"
+       y="26.16641"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS S<tspan
+   font-size="2.01064px"
+   x="71.044991"
+   y="26.16641"
+   id="tspan77"
+   >-</tspan><tspan
+   font-size="2.01064px"
+   x="71.887978"
+   y="26.16641"
+   id="tspan79"
+   >label</tspan><tspan
+   font-size="2.01064px"
+   x="68.33271"
+   y="28.679707"
+   id="tspan81"
+   >100</tspan></text>
+    <rect
+       x="53.687176"
+       y="34.175293"
+       width="16.942537"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect85" />
+    <text
+       font-size="2.01064px"
+       
+       x="63.732933"
+       y="33.454964"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS F<tspan
+   font-size="2.01064px"
+   x="70.990051"
+   y="33.454964"
+   id="tspan87"
+   >-</tspan><tspan
+   font-size="2.01064px"
+   x="71.833046"
+   y="33.454964"
+   id="tspan89"
+   >label</tspan><tspan
+   font-size="2.01064px"
+   x="67.16066"
+   y="35.968254"
+   id="tspan91"
+   >10000</tspan></text>
+    <rect
+       x="53.687176"
+       y="9.5239382"
+       width="16.942537"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect95" />
+    <text
+       font-size="2.89029px"
+       
+       x="64.722557"
+       y="13.222945"
+       
+       transform="scale(0.8869959,1.1274009)">DATA 1</text>
+    <rect
+       x="53.687176"
+       y="17.741053"
+       width="16.942537"
+       height="8.2171049"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect99" />
+    <text
+       font-size="2.89029px"
+       
+       x="65.052414"
+       y="19.254856"
+       
+       transform="scale(0.8869959,1.1274009)">IP <tspan
+   font-size="2.01064px"
+   x="68.790932"
+   y="19.254856"
+   id="tspan101"
+   >192.0.2.1</tspan><tspan
+   font-size="2.01064px"
+   x="68.754295"
+   y="21.893812"
+   id="tspan103"
+   >192.0.2.89</tspan></text>
+    <rect
+       x="140.40622"
+       y="116.9132"
+       width="16.942537"
+       height="8.2171049"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect107" />
+    <text
+       font-size="2.01064px"
+       
+       x="161.43571"
+       y="106.84313"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS S<tspan
+   font-size="2.01064px"
+   x="168.80281"
+   y="106.84313"
+   id="tspan109"
+   >-</tspan><tspan
+   font-size="2.01064px"
+   x="169.64581"
+   y="106.84313"
+   id="tspan111"
+   >label</tspan><tspan
+   font-size="2.01064px"
+   x="166.09053"
+   y="109.35642"
+   id="tspan113"
+   >100</tspan></text>
+    <rect
+       x="140.40622"
+       y="125.1303"
+       width="16.942537"
+       height="8.2171192"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect117" />
+    <text
+       font-size="2.01064px"
+       
+       x="161.48976"
+       y="114.25735"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS F<tspan
+   font-size="2.01064px"
+   x="168.74689"
+   y="114.25735"
+   id="tspan119"
+   >-</tspan><tspan
+   font-size="2.01064px"
+   x="169.5899"
+   y="114.25735"
+   id="tspan121"
+   >label</tspan><tspan
+   font-size="2.01064px"
+   x="164.91748"
+   y="116.77065"
+   id="tspan123"
+   >10003</tspan></text>
+    <rect
+       x="140.40622"
+       y="100.33727"
+       width="16.942537"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect127" />
+    <text
+       font-size="2.89029px"
+       
+       x="162.48"
+       y="93.774002"
+       
+       transform="scale(0.8869959,1.1274009)">DATA 1</text>
+    <rect
+       x="140.40622"
+       y="108.5544"
+       width="16.942537"
+       height="8.3588085"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect131" />
+    <text
+       font-size="2.89029px"
+       
+       x="162.80922"
+       y="99.93158"
+       
+       transform="scale(0.8869959,1.1274009)">IP <tspan
+   font-size="2.01064px"
+   x="166.54776"
+   y="99.93158"
+   id="tspan133"
+   >192.0.2.1</tspan><tspan
+   font-size="2.01064px"
+   x="166.51111"
+   y="102.57054"
+   id="tspan135"
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 51.569367,76.823112 c 0,-0.393324 -0.25086,-0.712175 -0.560313,-0.712175 H 44.88453 c -0.309456,0 -0.560317,0.318851 -0.560317,0.712175 v 6.226064 c 0,0.39333 0.250861,0.712165 0.560317,0.712165 h 6.124524 c 0.309453,0 0.560313,-0.318835 0.560313,-0.712165 z"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path139" />
+    <path
+       d="m 50.169934,76.677632 v 0.807713 h -1.48693 l -0.791955,1.812429 -0.808117,-1.812429 h -1.470765 v -0.807713 l -0.953587,1.024415 0.953587,1.02441 v -0.689505 h 1.05055 l 0.905085,1.989725 -0.905085,2.009426 h -1.05055 v -0.74861 l -0.953587,1.024421 0.953587,1.02442 v -0.768319 h 1.470765 l 0.808117,-1.851822 0.791955,1.851822 h 1.48693 v 0.728904 l 0.953574,-0.985005 -0.953574,-1.024421 v 0.74861 h -1.034386 l -0.921249,-2.009426 0.905084,-1.989725 h 1.050551 v 0.669811 l 0.953574,-1.004716 z"
+       stroke="#000000"
+       stroke-width="0.219914"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path141" />
+    <path
+       d="m 51.569367,79.993667 21.27035,-18.4752"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path143" />
+    <text
+       font-size="2.89029px"
+       
+       x="48.711845"
+       y="76.809273"
+       
+       transform="scale(0.8869959,1.1274009)">Ingress 2<tspan
+   font-size="2.89029px"
+   x="49.902328"
+   y="79.699562"
+   id="tspan145"
+   >192.0.2.23</tspan></text>
+    <path
+       d="m 166.04294,76.823117 c 0,-0.393329 -0.25085,-0.71218 -0.5603,-0.71218 h -6.23601 c -0.30945,0 -0.56032,0.318851 -0.56032,0.71218 v 6.226059 c 0,0.393314 0.25087,0.712182 0.56032,0.712182 h 6.23601 c 0.30945,0 0.5603,-0.318868 0.5603,-0.712182 z"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path149" />
+    <path
+       d="m 164.64351,76.677632 v 0.807713 h -1.48692 l -0.79196,1.812429 -0.80811,-1.812429 h -1.47077 v -0.807713 l -0.95359,1.024415 0.95359,1.02441 v -0.689505 h 1.05055 l 0.90508,1.989725 -0.90508,2.009426 h -1.05055 v -0.74861 l -0.95359,1.024421 0.95359,1.02442 v -0.768319 h 1.47077 l 0.80811,-1.851822 0.79196,1.851822 h 1.48692 v 0.728904 l 0.95358,-0.985005 -0.95358,-1.024421 v 0.74861 h -1.03438 l -0.92125,-2.009426 0.90509,-1.989725 h 1.05054 v 0.669811 l 0.95358,-1.004716 z"
+       stroke="#000000"
+       stroke-width="0.219914"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path151" />
+    <text
+       font-size="2.89029px"
+       
+       x="177.93549"
+       y="76.809273"
+       
+       transform="scale(0.8869959,1.1274009)">Egress 2<tspan
+   font-size="2.89029px"
+   x="178.7037"
+   y="79.699562"
+   id="tspan153"
+   >192.0.2.78</tspan></text>
+    <path
+       d="m 137.39669,61.518467 21.33867,18.459756"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path157" />
+    <text
+       font-size="2.89029px"
+       
+       x="16.292641"
+       y="31.444321"
+       
+       transform="scale(0.8869959,1.1274009)">Source 1<tspan
+   font-size="2.89029px"
+   x="17.354097"
+   y="34.33461"
+   id="tspan159"
+   >192.0.2.1</tspan></text>
+    <path
+       d="m 22.700176,25.820302 c 0,-0.393324 -0.25086,-0.712177 -0.560312,-0.712177 h -6.124523 c -0.309457,0 -0.560317,0.318853 -0.560317,0.712177 v 6.226064 c 0,0.39333 0.25086,0.712165 0.560317,0.712165 h 6.124523 c 0.309452,0 0.560312,-0.318835 0.560312,-0.712165 z"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path163" />
+    <path
+       d="m 21.300742,25.533149 v 0.824897 h -1.48693 l -0.791954,1.850991 -0.808114,-1.850991 h -1.470766 v -0.824897 l -0.953588,1.046208 0.953588,1.046208 v -0.704176 h 1.05055 l 0.905085,2.032064 -0.905085,2.052182 h -1.05055 v -0.764528 l -0.953588,1.046209 0.953588,1.046208 v -0.784662 h 1.470766 l 0.808114,-1.891226 0.791954,1.891226 h 1.48693 v 0.744427 l 0.953575,-1.005973 -0.953575,-1.046209 v 0.764528 h -1.034384 l -0.921251,-2.052182 0.905086,-2.032064 h 1.050549 v 0.68406 l 0.953575,-1.026092 z"
+       stroke="#000000"
+       stroke-width="0.219914"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path165" />
+    <path
+       d="M 22.700176,28.933336 44.187213,61.526119"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path167" />
+    <rect
+       x="25.26384"
+       y="9.5239382"
+       width="16.942537"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect169" />
+    <text
+       font-size="2.89029px"
+       
+       x="32.67403"
+       y="13.222945"
+       
+       transform="scale(0.8869959,1.1274009)">DATA 1</text>
+    <rect
+       x="25.26384"
+       y="17.599375"
+       width="16.942537"
+       height="8.2171049"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect173" />
+    <text
+       font-size="2.89029px"
+       
+       x="33.003895"
+       y="19.254856"
+       
+       transform="scale(0.8869959,1.1274009)">IP <tspan
+   font-size="2.01064px"
+   x="36.742413"
+   y="19.254856"
+   id="tspan175"
+   >192.0.2.1</tspan><tspan
+   font-size="2.01064px"
+   x="36.705769"
+   y="21.893812"
+   id="tspan177"
+   >192.0.2.89</tspan><tspan
+   font-size="2.89029px"
+   x="16.186686"
+   y="105.71215"
+   id="tspan179"
+   >Source 2</tspan><tspan
+   font-size="2.89029px"
+   x="17.248201"
+   y="108.60243"
+   id="tspan181"
+   >192.0.2.12</tspan></text>
+    <path
+       d="m 22.58871,109.40824 c 0,-0.39331 -0.250862,-0.71217 -0.560314,-0.71217 h -6.124522 c -0.309457,0 -0.560317,0.31886 -0.560317,0.71217 v 6.22606 c 0,0.39334 0.25086,0.71217 0.560317,0.71217 h 6.124522 c 0.309452,0 0.560314,-0.31883 0.560314,-0.71217 z"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path185" />
+    <path
+       d="m 21.18928,109.26277 v 0.8077 h -1.48693 l -0.791954,1.81244 -0.808115,-1.81244 h -1.470765 v -0.8077 l -0.953588,1.02441 0.953588,1.02443 v -0.68952 h 1.050549 l 0.905085,1.98973 -0.905085,2.00944 h -1.050549 v -0.74861 l -0.953588,1.0244 0.953588,1.02443 v -0.76832 h 1.470765 l 0.808115,-1.85182 0.791954,1.85182 h 1.48693 v 0.72892 l 0.953575,-0.98503 -0.953575,-1.0244 v 0.74861 h -1.034386 l -0.921249,-2.00944 0.905085,-1.98973 h 1.05055 v 0.66982 l 0.953575,-1.00473 z"
+       stroke="#000000"
+       stroke-width="0.219914"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path187" />
+    <path
+       d="M 22.58871,112.5312 44.28374,79.936715"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path189" />
+    <text
+       font-size="2.89029px"
+       
+       x="207.72052"
+       y="105.71215"
+       
+       transform="scale(0.8869959,1.1274009)">Destination 2<tspan
+   font-size="2.89029px"
+   x="211.54996"
+   y="108.60243"
+   id="tspan191"
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 194.91213,109.54992 c 0,-0.39332 -0.25085,-0.71217 -0.5603,-0.71217 h -6.12455 c -0.30945,0 -0.56032,0.31885 -0.56032,0.71217 v 6.22609 c 0,0.39331 0.25087,0.71217 0.56032,0.71217 h 6.12455 c 0.30945,0 0.5603,-0.31886 0.5603,-0.71217 z"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path195" />
+    <path
+       d="m 193.5127,109.40444 v 0.80771 h -1.48692 l -0.79195,1.81243 -0.80812,-1.81243 h -1.47077 v -0.80771 l -0.95359,1.02441 0.95359,1.02442 v -0.68951 h 1.05056 l 0.90507,1.98972 -0.90507,2.00943 h -1.05056 v -0.74861 l -0.95359,1.02442 0.95359,1.02442 v -0.76832 h 1.47077 l 0.80812,-1.85182 0.79195,1.85182 h 1.48692 v 0.7289 l 0.95358,-0.985 -0.95358,-1.02442 v 0.74861 h -1.03438 l -0.92125,-2.00943 0.90509,-1.98972 h 1.05054 v 0.66982 l 0.95358,-1.00473 z"
+       stroke="#000000"
+       stroke-width="0.219914"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path197" />
+    <path
+       d="m 166.04294,79.936147 21.63853,32.712643"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path199" />
+    <text
+       font-size="2.89029px"
+       
+       x="207.48428"
+       y="31.444321"
+       
+       transform="scale(0.8869959,1.1274009)">Destination 1<tspan
+   font-size="2.89029px"
+   x="211.31371"
+   y="34.33461"
+   id="tspan201"
+   >192.0.2.88</tspan></text>
+    <path
+       d="m 194.68921,25.678628 c 0,-0.393324 -0.25086,-0.712175 -0.56032,-0.712175 h -6.12454 c -0.30946,0 -0.56031,0.318851 -0.56031,0.712175 v 6.226092 c 0,0.393318 0.25085,0.71217 0.56031,0.71217 h 6.12454 c 0.30946,0 0.56032,-0.318852 0.56032,-0.71217 z"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path205" />
+    <path
+       d="m 193.38481,25.533149 v 0.807714 h -1.51257 l -0.8056,1.812428 -0.82205,-1.812428 h -1.49612 v -0.807714 l -0.97002,1.024414 0.97002,1.02441 v -0.689504 h 1.06865 l 0.9207,1.989726 -0.9207,2.009424 h -1.06865 v -0.748608 l -0.97002,1.02442 0.97002,1.02442 v -0.768319 h 1.49612 l 0.82205,-1.851823 0.8056,1.851823 h 1.51257 v 0.728903 l 0.97001,-0.985004 -0.97001,-1.02442 v 0.748608 h -1.05223 l -0.93714,-2.009424 0.9207,-1.989726 h 1.06867 v 0.66981 l 0.97001,-1.004716 z"
+       stroke="#000000"
+       stroke-width="0.219914"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       fill="none"
+       fill-rule="evenodd"
+       id="path207" />
+    <path
+       d="M 166.04294,61.447347 187.42733,28.791664"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path209" />
+    <rect
+       x="168.27223"
+       y="116.77151"
+       width="17.054001"
+       height="8.2171049"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect211" />
+    <text
+       font-size="2.89029px"
+       
+       x="193.95146"
+       y="108.3511"
+       
+       transform="scale(0.8869959,1.1274009)">DATA 1</text>
+    <rect
+       x="168.27223"
+       y="125.1303"
+       width="17.054001"
+       height="8.2171192"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect215" />
+    <text
+       font-size="2.89029px"
+       
+       x="194.28195"
+       y="114.50868"
+       
+       transform="scale(0.8869959,1.1274009)">IP <tspan
+   font-size="2.01064px"
+   x="198.02048"
+   y="114.50868"
+   id="tspan217"
+   >192.0.2.1</tspan><tspan
+   font-size="2.01064px"
+   x="197.98383"
+   y="117.14764"
+   id="tspan219"
+   >192.0.2.89</tspan></text>
+    <path
+       d="m 41.361042,59.816531 c -0.123281,-0.189419 0.259934,-0.850898 0.855819,-1.477523 0.595886,-0.626769 1.178843,-0.98124 1.302123,-0.791959 0.12328,0.189419 -0.259821,0.850897 -0.85582,1.477661 -0.595886,0.626626 -1.178843,0.981097 -1.302122,0.791821 L 23.551312,32.45735 c -0.123279,-0.189421 0.259936,-0.850899 0.855821,-1.477668 0.59589,-0.626625 1.178846,-0.981236 1.302126,-0.791816 l 17.809725,27.359321"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path223" />
+    <text
+       font-size="2.89029px"
+       transform="matrix(0.56544019,0.86862717,-0.68340262,0.71869303,0,0)"
+       
+       x="47.197205"
+       y="-6.7317076"
+       >App-1</text>
+    <path
+       d="m 70.991976,65.48535 c -0.415534,0 -0.752379,-1.712559 -0.752379,-3.82521 0,-2.112652 0.336845,-3.825211 0.752379,-3.825211 0.41554,0 0.752384,1.712559 0.752384,3.825211 0,2.112651 -0.336844,3.82521 -0.752384,3.82521 H 52.990535 c -0.415539,0 -0.752383,-1.712559 -0.752383,-3.82521 0,-2.112652 0.336844,-3.825211 0.752383,-3.825211 h 18.001441"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path231" />
+    <text
+       font-size="2.89029px"
+       
+       x="67.196251"
+       y="50.545357"
+       
+       transform="scale(0.8869959,1.1274009)">DN - 1</text>
+    <path
+       d="m 185.06317,111.78883 c -0.1226,-0.18843 0.25972,-0.85006 0.85605,-1.47768 0.59633,-0.6262 1.17929,-0.98038 1.3019,-0.79195 0.12372,0.18984 -0.25972,0.85146 -0.85605,1.47766 -0.59521,0.62761 -1.17818,0.98181 -1.3019,0.79197 L 167.25344,84.42992 c -0.1226,-0.189275 0.25972,-0.850898 0.85605,-1.477523 0.59633,-0.626769 1.17929,-0.981235 1.3019,-0.791821 l 17.80973,27.358624"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path237" />
+    <text
+       font-size="2.89029px"
+       transform="matrix(0.56544019,0.86862717,-0.68340262,0.71869303,0,0)"
+       
+       x="195.54936"
+       y="-93.777214"
+       >App-1</text>
+    <path
+       d="m 155.8295,82.063674 c -0.34777,-0.286607 0.10147,-1.952275 1.00318,-3.720373 0.90285,-1.768237 1.91606,-2.969215 2.26383,-2.682609 0.34777,0.286612 -0.10147,1.952275 -1.0043,3.720518 -0.90174,1.768097 -1.91494,2.96907 -2.26271,2.682464 L 137.63968,67.072815 c -0.34777,-0.286606 0.10147,-1.952275 1.00317,-3.720373 0.90175,-1.768097 1.91496,-2.96907 2.26272,-2.682463 l 18.19094,14.990713"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path245" />
+    <text
+       font-size="2.89029px"
+       transform="matrix(0.74424382,0.61334792,-0.48255869,0.94595832,0,0)"
+       
+       x="174.42027"
+       y="-32.033894"
+       >DN-1</text>
+    <path
+       d="m 187.20106,32.580607 c -0.12373,0.188569 -0.70558,-0.170009 -1.29856,-0.800607 -0.59299,-0.630732 -0.97308,-1.294903 -0.84936,-1.483328 0.12373,-0.188568 0.70558,0.169865 1.29856,0.800602 0.59298,0.630732 0.9742,1.29476 0.84936,1.483333 l -17.92343,27.238051 c -0.12483,0.188568 -0.70557,-0.169871 -1.29967,-0.800604 -0.59299,-0.630737 -0.97308,-1.294908 -0.84935,-1.483332 l 17.92453,-27.23805"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path253" />
+    <text
+       font-size="2.89029px"
+       transform="matrix(0.56907889,-0.86477972,0.6803756,0.72331795,0,0)"
+       
+       x="98.202126"
+       y="175.42856"
+       >App-2</text>
+    <path
+       d="m 43.795079,84.500189 c -0.124059,0.188568 -0.705566,-0.169865 -1.298887,-0.800602 -0.593214,-0.630733 -0.97364,-1.294904 -0.84958,-1.483334 0.124058,-0.188568 0.705565,0.169871 1.29889,0.800609 0.593211,0.630732 0.973641,1.294903 0.849577,1.483327 L 25.87077,111.73782 c -0.124059,0.18843 -0.705566,-0.17001 -1.298891,-0.80046 -0.59321,-0.63045 -0.973641,-1.29491 -0.849581,-1.48333 L 41.646612,82.216253"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path261" />
+    <text
+       font-size="2.89029px"
+       transform="matrix(0.56907889,-0.86477972,0.6803756,0.72331795,0,0)"
+       
+       x="-50.722839"
+       y="89.435524"
+       >App-2</text>
+    <path
+       d="m 73.207327,67.227237 c -0.348884,0.284342 -1.35741,-0.922865 -2.252579,-2.696488 -0.895168,-1.773762 -1.338125,-3.442124 -0.989241,-3.726605 0.34888,-0.28448 1.357408,0.922725 2.252576,2.696488 0.895168,1.773623 1.338124,3.442124 0.989244,3.726605 L 54.960102,82.105182 C 54.611221,82.389663 53.602695,81.182457 52.707527,79.408695 51.812358,77.635072 51.369512,75.96657 51.718281,75.682228 L 69.965507,60.804144"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path269" />
+    <text
+       font-size="2.89029px"
+       transform="matrix(0.74658424,-0.60873544,0.47892975,0.94893308,0,0)"
+       
+       x="18.17164"
+       y="97.53714"
+       >DN-2</text>
+    <path
+       d="m 156.93077,65.343678 c -0.41577,0 -0.75239,-1.712565 -0.75239,-3.825211 0,-2.112652 0.33662,-3.82521 0.75239,-3.82521 0.41576,0 0.75237,1.712558 0.75237,3.82521 0,2.112646 -0.33661,3.825211 -0.75237,3.825211 h -18.00145 c -0.41576,0 -0.75239,-1.712565 -0.75239,-3.825211 0,-2.112652 0.33663,-3.82521 0.75239,-3.82521 h 18.00145"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path277" />
+    <text
+       font-size="2.89029px"
+       
+       x="164.04576"
+       y="50.545357"
+       
+       transform="scale(0.8869959,1.1274009)">DN-2</text>
+    <path
+       d="m 130.89499,68.743865 c -0.55732,0.4671 -2.20141,-1.451028 -3.67163,-4.284235 -1.4691,-2.833209 -2.20921,-5.508733 -1.6519,-5.975832 0.55733,-0.466957 2.20031,1.451172 3.67052,4.284379 1.4702,2.833203 2.20922,5.508588 1.65301,5.975688 l -17.61021,14.759501 c -0.55731,0.467105 -2.2003,-1.451028 -3.67051,-4.284236 -1.47021,-2.833201 -2.20921,-5.508581 -1.6519,-5.975688 l 17.60909,-14.7595"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path283" />
+    <text
+       font-size="2.89029px"
+       transform="matrix(0.7404872,-0.62064996,0.48830365,0.94118354,0,0)"
+       
+       x="70.416733"
+       y="125.34568"
+       >DN-1 / DN-2</text>
+    <path
+       d="m 96.788328,83.168874 c -0.553529,-0.47404 0.207318,-3.139931 1.699378,-5.954435 1.49161,-2.814364 3.150194,-4.711524 3.704174,-4.237485 0.55286,0.474184 -0.20732,3.140075 -1.69983,5.95444 -1.491383,2.814504 -3.150081,4.711664 -3.703722,4.23748 L 79.295716,68.186802 c -0.55353,-0.474184 0.207322,-3.140076 1.699382,-5.954441 1.492058,-2.814503 3.150419,-4.711663 3.703949,-4.237623 l 17.492833,14.982216"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       fill-rule="evenodd"
+       id="path295" />
+    <text
+       font-size="2.89029px"
+       transform="matrix(0.73557772,0.6300108,-0.49566839,0.93494343,0,0)"
+       
+       x="112.23055"
+       y="-6.1905408"
+       >DN-1 / DN-2</text>
+    <rect
+       x="53.687176"
+       y="116.9132"
+       width="16.942537"
+       height="8.2171049"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect307" />
+    <text
+       font-size="2.01064px"
+       
+       x="63.677887"
+       y="106.84313"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS S<tspan
+   font-size="2.01064px"
+   x="71.044991"
+   y="106.84313"
+   id="tspan309"
+   >-</tspan><tspan
+   font-size="2.01064px"
+   x="71.887978"
+   y="106.84313"
+   id="tspan311"
+   >label</tspan><tspan
+   font-size="2.01064px"
+   x="68.33271"
+   y="109.35642"
+   id="tspan313"
+   >101</tspan></text>
+    <rect
+       x="53.687176"
+       y="125.1303"
+       width="16.942537"
+       height="8.2171192"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect317" />
+    <text
+       font-size="2.01064px"
+       
+       x="63.732933"
+       y="114.25735"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS F<tspan
+   font-size="2.01064px"
+   x="70.990051"
+   y="114.25735"
+   id="tspan319"
+   >-</tspan><tspan
+   font-size="2.01064px"
+   x="71.833046"
+   y="114.25735"
+   id="tspan321"
+   >label</tspan><tspan
+   font-size="2.01064px"
+   x="67.16066"
+   y="116.77065"
+   id="tspan323"
+   >10004</tspan></text>
+    <rect
+       x="53.687176"
+       y="100.33727"
+       width="16.942537"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect327" />
+    <text
+       font-size="2.89029px"
+       
+       x="64.722557"
+       y="93.774002"
+       
+       transform="scale(0.8869959,1.1274009)">DATA 2</text>
+    <rect
+       x="53.687176"
+       y="108.5544"
+       width="16.942537"
+       height="8.3588085"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect331" />
+    <text
+       font-size="2.89029px"
+       
+       x="65.052414"
+       y="99.93158"
+       
+       transform="scale(0.8869959,1.1274009)">IP <tspan
+   font-size="2.01064px"
+   x="68.790932"
+   y="99.93158"
+   id="tspan333"
+   >192.0.2.12</tspan><tspan
+   font-size="2.01064px"
+   x="68.754295"
+   y="102.57054"
+   id="tspan335"
+   >192.0.2.88</tspan></text>
+    <rect
+       x="25.26384"
+       y="116.77151"
+       width="16.942537"
+       height="8.2171049"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect339" />
+    <text
+       font-size="2.89029px"
+       
+       x="32.67403"
+       y="108.3511"
+       
+       transform="scale(0.8869959,1.1274009)">DATA 2</text>
+    <rect
+       x="25.26384"
+       y="125.1303"
+       width="16.942537"
+       height="8.2171192"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect343" />
+    <text
+       font-size="2.89029px"
+       
+       x="33.003895"
+       y="114.50868"
+       
+       transform="scale(0.8869959,1.1274009)">IP <tspan
+   font-size="2.01064px"
+   x="36.742413"
+   y="114.50868"
+   id="tspan345"
+   >192.0.2.12</tspan><tspan
+   font-size="2.01064px"
+   x="36.705769"
+   y="117.14764"
+   id="tspan347"
+   >192.0.2.88</tspan></text>
+    <rect
+       x="82.22197"
+       y="42.109062"
+       width="16.942537"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect351" />
+    <text
+       font-size="2.01064px"
+       
+       x="95.908493"
+       y="40.49218"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS F<tspan
+   font-size="2.01064px"
+   x="103.16564"
+   y="40.49218"
+   id="tspan353"
+   >-</tspan><tspan
+   font-size="2.01064px"
+   x="104.00863"
+   y="40.49218"
+   id="tspan355"
+   >label</tspan><tspan
+   font-size="2.01064px"
+   x="99.33622"
+   y="43.005478"
+   id="tspan357"
+   >20000</tspan></text>
+    <rect
+       x="110.97971"
+       y="42.109062"
+       width="16.942537"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect361" />
+    <text
+       font-size="2.01064px"
+       
+       x="128.31929"
+       y="40.49218"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS F<tspan
+   font-size="2.01064px"
+   x="135.57645"
+   y="40.49218"
+   id="tspan363"
+   >-</tspan><tspan
+   font-size="2.01064px"
+   x="136.41945"
+   y="40.49218"
+   id="tspan365"
+   >label</tspan><tspan
+   font-size="2.01064px"
+   x="131.74704"
+   y="43.005478"
+   id="tspan367"
+   >20001</tspan></text>
+    <rect
+       x="82.22197"
+       y="25.816498"
+       width="8.4712687"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect371" />
+    <text
+       font-size="1.50798px"
+       
+       x="95.527481"
+       y="24.909765"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS<tspan
+   font-size="1.50798px"
+   x="95.087646"
+   y="26.669069"
+   id="tspan373"
+   >S</tspan><tspan
+   font-size="1.50798px"
+   x="95.930649"
+   y="26.669069"
+   id="tspan375"
+   >-</tspan><tspan
+   font-size="1.50798px"
+   x="96.553749"
+   y="26.669069"
+   id="tspan377"
+   >label</tspan><tspan
+   font-size="2.01064px"
+   x="95.72834"
+   y="29.0567"
+   id="tspan379"
+   >100</tspan></text>
+    <rect
+       x="90.693245"
+       y="25.816498"
+       width="8.4712687"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect383" />
+    <text
+       font-size="1.50798px"
+       
+       x="105.08591"
+       y="24.909765"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS<tspan
+   font-size="1.50798px"
+   x="104.64607"
+   y="26.669069"
+   id="tspan385"
+   >S</tspan><tspan
+   font-size="1.50798px"
+   x="105.48909"
+   y="26.669069"
+   id="tspan387"
+   >-</tspan><tspan
+   font-size="1.50798px"
+   x="106.11217"
+   y="26.669069"
+   id="tspan389"
+   >label</tspan><tspan
+   font-size="2.01064px"
+   x="105.28677"
+   y="29.0567"
+   id="tspan391"
+   >101</tspan></text>
+    <rect
+       x="82.22197"
+       y="17.599375"
+       width="8.4712687"
+       height="8.2171049"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect395" />
+    <text
+       font-size="1.63364px"
+       
+       x="96.73774"
+       y="17.998205"
+       
+       transform="scale(0.8869959,1.1274009)">IP<tspan
+   font-size="1.63364px"
+   x="94.922729"
+   y="19.883175"
+   id="tspan397"
+   >192.0.2.1</tspan><tspan
+   font-size="1.63364px"
+   x="94.922729"
+   y="21.768145"
+   id="tspan399"
+   >192.0.2.89</tspan></text>
+    <rect
+       x="90.693245"
+       y="17.599375"
+       width="8.4712687"
+       height="8.2171049"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect403" />
+    <text
+       font-size="1.63364px"
+       
+       x="106.29618"
+       y="17.998205"
+       
+       transform="scale(0.8869959,1.1274009)">IP<tspan
+   font-size="1.63364px"
+   x="104.48116"
+   y="19.883175"
+   id="tspan405"
+   >192.0.2.12</tspan><tspan
+   font-size="1.63364px"
+   x="104.48116"
+   y="21.768145"
+   id="tspan407"
+   >192.0.2.88</tspan></text>
+    <rect
+       x="82.22197"
+       y="9.5239382"
+       width="8.4712687"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect411" />
+    <text
+       font-size="1.75931px"
+       
+       x="95.069427"
+       y="11.714975"
+       
+       transform="scale(0.8869959,1.1274009)">DATA <tspan
+   font-size="1.75931px"
+   x="96.975342"
+   y="13.851271"
+   id="tspan413"
+   >1</tspan></text>
+    <rect
+       x="90.693245"
+       y="9.5239382"
+       width="8.4712687"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect417" />
+    <text
+       font-size="1.75931px"
+       
+       x="104.62786"
+       y="11.714975"
+       
+       transform="scale(0.8869959,1.1274009)">DATA <tspan
+   font-size="1.75931px"
+   x="106.53378"
+   y="13.851271"
+   id="tspan419"
+   >2</tspan></text>
+    <rect
+       x="110.97971"
+       y="25.816498"
+       width="8.4712687"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect423" />
+    <text
+       font-size="1.50798px"
+       
+       x="127.93854"
+       y="24.909765"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS<tspan
+   font-size="1.50798px"
+   x="127.49872"
+   y="26.669069"
+   id="tspan425"
+   >S</tspan><tspan
+   font-size="1.50798px"
+   x="128.34172"
+   y="26.669069"
+   id="tspan427"
+   >-</tspan><tspan
+   font-size="1.50798px"
+   x="128.9648"
+   y="26.669069"
+   id="tspan429"
+   >label</tspan><tspan
+   font-size="2.01064px"
+   x="128.13939"
+   y="29.0567"
+   id="tspan431"
+   >100</tspan></text>
+    <rect
+       x="119.45098"
+       y="25.816498"
+       width="8.4712687"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect435" />
+    <text
+       font-size="1.50798px"
+       
+       x="137.4966"
+       y="24.909765"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS<tspan
+   font-size="1.50798px"
+   x="137.05678"
+   y="26.669069"
+   id="tspan437"
+   >S</tspan><tspan
+   font-size="1.50798px"
+   x="137.89978"
+   y="26.669069"
+   id="tspan439"
+   >-</tspan><tspan
+   font-size="1.50798px"
+   x="138.52286"
+   y="26.669069"
+   id="tspan441"
+   >label</tspan><tspan
+   font-size="2.01064px"
+   x="137.69746"
+   y="29.0567"
+   id="tspan443"
+   >101</tspan></text>
+    <rect
+       x="110.97971"
+       y="17.599375"
+       width="8.4712687"
+       height="8.2171049"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect447" />
+    <text
+       font-size="1.63364px"
+       
+       x="129.14868"
+       y="17.998205"
+       
+       transform="scale(0.8869959,1.1274009)">IP<tspan
+   font-size="1.63364px"
+   x="127.33365"
+   y="19.883175"
+   id="tspan449"
+   >192.0.2.1</tspan><tspan
+   font-size="1.63364px"
+   x="127.33365"
+   y="21.768145"
+   id="tspan451"
+   >192.0.2.89</tspan></text>
+    <rect
+       x="119.45098"
+       y="17.599375"
+       width="8.4712687"
+       height="8.2171049"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect455" />
+    <text
+       font-size="1.63364px"
+       
+       x="138.70676"
+       y="17.998205"
+       
+       transform="scale(0.8869959,1.1274009)">IP<tspan
+   font-size="1.63364px"
+   x="136.89171"
+   y="19.883175"
+   id="tspan457"
+   >192.0.2.12</tspan><tspan
+   font-size="1.63364px"
+   x="136.89171"
+   y="21.768145"
+   id="tspan459"
+   >192.0.2.88</tspan></text>
+    <rect
+       x="110.97971"
+       y="9.5239382"
+       width="8.4712687"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect463" />
+    <text
+       font-size="1.75931px"
+       
+       x="127.47987"
+       y="11.714975"
+       
+       transform="scale(0.8869959,1.1274009)">DATA <tspan
+   font-size="1.75931px"
+   x="129.38576"
+   y="13.851271"
+   id="tspan465"
+   >1</tspan></text>
+    <rect
+       x="119.45098"
+       y="9.5239382"
+       width="8.4712687"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect469" />
+    <text
+       font-size="1.75931px"
+       
+       x="137.03792"
+       y="11.714975"
+       
+       transform="scale(0.8869959,1.1274009)">DATA <tspan
+   font-size="1.75931px"
+   x="138.94382"
+   y="13.851271"
+   id="tspan471"
+   >2</tspan></text>
+    <rect
+       x="82.22197"
+       y="33.891949"
+       width="8.4712687"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect475" />
+    <text
+       font-size="1.50798px"
+       
+       x="95.528229"
+       y="32.323982"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS F-label<tspan
+   font-size="1.75931px"
+   x="94.922752"
+   y="36.219585"
+   id="tspan481"
+   >10002</tspan></text>
+    <rect
+       x="90.693245"
+       y="33.891949"
+       width="8.4712687"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect485" />
+    <text
+       font-size="1.50798px"
+       
+       x="105.08666"
+       y="32.323982"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS F-label<tspan
+   font-size="1.75931px"
+   x="104.48116"
+   y="36.219585"
+   id="tspan491"
+   >10006</tspan></text>
+    <rect
+       x="110.97971"
+       y="33.891949"
+       width="8.4712687"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect495" />
+    <text
+       font-size="1.50798px"
+       
+       x="127.93854"
+       y="32.323982"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS F-label<tspan
+   font-size="1.75931px"
+   x="127.33303"
+   y="36.219585"
+   id="tspan501"
+   >10002</tspan></text>
+    <rect
+       x="119.45098"
+       y="33.891949"
+       width="8.4712687"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect505" />
+    <text
+       font-size="1.50798px"
+       
+       x="137.4966"
+       y="32.323982"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS F-label<tspan
+   font-size="1.75931px"
+   x="136.8911"
+   y="36.219585"
+   id="tspan511"
+   >10006</tspan></text>
+    <rect
+       x="139.51451"
+       y="25.958176"
+       width="16.942537"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect515" />
+    <text
+       font-size="2.01064px"
+       
+       x="160.39145"
+       y="26.16641"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS S<tspan
+   font-size="2.01064px"
+   x="167.75854"
+   y="26.16641"
+   id="tspan517"
+   >-</tspan><tspan
+   font-size="2.01064px"
+   x="168.60155"
+   y="26.16641"
+   id="tspan519"
+   >label</tspan><tspan
+   font-size="2.01064px"
+   x="165.04628"
+   y="28.679707"
+   id="tspan521"
+   >101</tspan></text>
+    <rect
+       x="139.51451"
+       y="34.175293"
+       width="16.942537"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect525" />
+    <text
+       font-size="2.01064px"
+       
+       x="160.44673"
+       y="33.580624"
+       
+       transform="scale(0.8869959,1.1274009)">MPLS F<tspan
+   font-size="2.01064px"
+   x="167.70387"
+   y="33.580624"
+   id="tspan527"
+   >-</tspan><tspan
+   font-size="2.01064px"
+   x="168.54688"
+   y="33.580624"
+   id="tspan529"
+   >label</tspan><tspan
+   font-size="2.01064px"
+   x="163.87445"
+   y="36.093918"
+   id="tspan531"
+   >10007</tspan></text>
+    <rect
+       x="139.51451"
+       y="9.5239382"
+       width="16.942537"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect535" />
+    <text
+       font-size="2.89029px"
+       
+       x="161.43571"
+       y="13.222945"
+       
+       transform="scale(0.8869959,1.1274009)">DATA 2</text>
+    <rect
+       x="139.51451"
+       y="17.741053"
+       width="16.942537"
+       height="8.2171049"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect539" />
+    <text
+       font-size="2.89029px"
+       
+       x="161.7662"
+       y="19.254856"
+       
+       transform="scale(0.8869959,1.1274009)">IP <tspan
+   font-size="2.01064px"
+   x="165.50475"
+   y="19.254856"
+   id="tspan541"
+   >192.0.2.12</tspan><tspan
+   font-size="2.01064px"
+   x="165.46808"
+   y="21.893812"
+   id="tspan543"
+   >192.0.2.88</tspan></text>
+    <rect
+       x="168.27223"
+       y="9.5239382"
+       width="17.054001"
+       height="8.2171326"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect547" />
+    <text
+       font-size="2.89029px"
+       
+       x="193.95146"
+       y="13.222945"
+       
+       transform="scale(0.8869959,1.1274009)">DATA 2</text>
+    <rect
+       x="168.27223"
+       y="17.741053"
+       width="17.054001"
+       height="8.3587809"
+       stroke="#000000"
+       stroke-width="0.293217"
+       stroke-miterlimit="8"
+       fill="none"
+       id="rect551" />
+    <text
+       font-size="2.89029px"
+       
+       x="194.28195"
+       y="19.380524"
+       
+       transform="scale(0.8869959,1.1274009)">IP <tspan
+   font-size="2.01064px"
+   x="198.02048"
+   y="19.380524"
+   id="tspan553"
+   >192.0.2.12</tspan><tspan
+   font-size="2.01064px"
+   x="197.98383"
+   y="22.019478"
+   id="tspan555"
+   >192.0.2.88</tspan></text>
+    <path
+       d="m 68.567636,54.008021 c 0,-0.351216 0.223928,-0.635835 0.500252,-0.635835 h 14.493 c 0.276209,0 0.50025,0.284619 0.50025,0.635835 v 19.554478 c 0,0.35121 -0.224041,0.635834 -0.50025,0.635834 h -14.493 c -0.276324,0 -0.500252,-0.284624 -0.500252,-0.635834 z"
+       stroke="#000000"
+       stroke-width="0.586434"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.34575, 1.75931"
+       fill="none"
+       fill-rule="evenodd"
+       id="path559" />
+    <path
+       d="m 125.52577,53.893828 c 0,-0.366369 0.23406,-0.663321 0.52165,-0.663321 h 15.11898 c 0.28758,0 0.52165,0.296952 0.52165,0.663321 v 19.499507 c 0,0.366374 -0.23407,0.66332 -0.52165,0.66332 h -15.11898 c -0.28759,0 -0.52165,-0.296946 -0.52165,-0.66332 z"
+       stroke="#000000"
+       stroke-width="0.586434"
+       stroke-miterlimit="8"
+       stroke-dasharray="2.34575, 1.75931"
+       fill="none"
+       fill-rule="evenodd"
+       id="path561" />
+    <text
+       font-size="2.89029px"
+       
+       x="79.049828"
+       y="72.159683"
+       
+       transform="scale(0.8869959,1.1274009)">aggregation<tspan
+   font-size="2.89029px"
+   x="141.99666"
+   y="72.159683"
+   id="tspan563"
+   >disaggregation</tspan></text>
+  </g>
+</svg>
+</artwork>
+</artset>
+        </figure>
+        <figure anchor="example-detnet-json-forwarding-aggregation-d-1">
+          <name>Example D-1 DetNet JSON Relay Service Sub-Layer Aggregation</name>
+          <artwork name="" type="" align="left" alt=""><![CDATA[
+{
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "eth0",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth1",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth2",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth3",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth4",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      }
+    ]
+  },
+  "ietf-detnet:detnet": {
+    "traffic-profile": [
+      {
+        "profile-name": "pf-1",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 1,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "fsl-1",
+          "fsl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-2",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 2,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "afl-1"
+        ]
+      }
+    ],
+    "forwarding-sub-layer": {
+      "forwarding-sub-layer-list": [
+        {
+          "name": "fsl-1",
+          "traffic-profile": "pf-1",
+          "forwarding-operation-type": "pop-impose-and-forward",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth0",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10000
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "aggregation-forwarding-sub-layer": "afl-1",
+              "forwarding-label": {
+                "mpls-label-stack": {
+                  "entry": [
+                    {
+                      "id": 0,
+                      "label": 10002
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "fsl-2",
+          "traffic-profile": "pf-1",
+          "forwarding-operation-type": "pop-impose-and-forward",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10004
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-sub-layer": {
+              "aggregation-forwarding-sub-layer": "afl-1",
+              "forwarding-label": {
+                "mpls-label-stack": {
+                  "entry": [
+                    {
+                      "id": 0,
+                      "label": 10006
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "afl-1",
+          "traffic-profile": "pf-2",
+          "forwarding-operation-type": "impose-and-forward",
+          "incoming-type": {
+            "forwarding-aggregation": {
+              "forwarding-sub-layer": [
+                "fsl-1",
+                "fsl-2"
+              ]
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth3",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20000
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+]]></artwork>
+        </figure>
+        <figure anchor="example-detnet-json-forwarding-disaggregation-d-1">
+          <name>Example D-1 DetNet JSON Relay Service Sub-Layer Disaggregation</name>
+          <artwork name="" type="" align="left" alt=""><![CDATA[
+{
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "eth0",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth1",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth2",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth3",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      },
+      {
+        "name": "eth4",
+        "type": "iana-if-type:ethernetCsmacd",
+        "oper-status": "up",
+        "statistics": {
+          "discontinuity-time": "2020-12-18T23:59:00Z"
+        }
+      }
+    ]
+  },
+  "ietf-detnet:detnet": {
+    "traffic-profile": [
+      {
+        "profile-name": "pf-1",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 1,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "fsl-1",
+          "fsl-2"
+        ]
+      },
+      {
+        "profile-name": "pf-2",
+        "flow-spec": {
+          "interval": 125,
+          "max-pkts-per-interval": 2,
+          "max-payload-size": 1518
+        },
+        "member-fwd-sublayers": [
+          "afl-1"
+        ]
+      }
+    ],
+    "forwarding-sub-layer": {
+      "forwarding-sub-layer-list": [
+        {
+          "name": "fsl-1",
+          "traffic-profile": "pf-1",
+          "forwarding-operation-type": "swap-and-forward",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10002
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth3",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10003
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "fsl-2",
+          "traffic-profile": "pf-1",
+          "forwarding-operation-type": "swap-and-forward",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10006
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "interface": {
+              "outgoing-interface": "eth2",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 10007
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "afl-1",
+          "traffic-profile": "pf-2",
+          "forwarding-operation-type": "pop-and-lookup",
+          "incoming-type": {
+            "forwarding-id": {
+              "interface": "eth1",
+              "mpls-label-stack": {
+                "entry": [
+                  {
+                    "id": 0,
+                    "label": 20001
+                  }
+                ]
+              }
+            }
+          },
+          "outgoing-type": {
+            "forwarding-disaggregation": {
+              "forwarding-sub-layer": [
+                "fsl-1",
+                "fsl-2"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+]]></artwork>
+        </figure>
+      </section>
+    </section>
+  </back>
+</rfc>


### PR DESCRIPTION
This update changes the SVG version.  Now the YANG modules must be extracted updated and validated and put back in the xml.

TP02: IANA Considerations MUST be present as per YANG Guidelines, RftFC8407; no registration, no YANG module
TP03: Security Considerations MUST follow the template as per YANG Guidelines
TP04: Examples MUST use the addresses reserved for IETF documentation, not those allocated to other organisations.
The new addresses chosen mess up the SVG the alignment is off.  It is several hours of work to fix this. 
Primarily it is 1.1.1.1 (7 chars)  192.0.2.1 (9-10 chars) - There may not be an easy way to move the SVG coordinates without redoing the conversion process. 
TP05: Requirements Language is out of date - see RFC8174
TP06: YANG revision statement must refer to the title i.e. 'RFC XXXX; Determistic Networking (DetNet) YANG Model'
TP07: The Information Model is now an RFC
TP09: import yang-types references an obsolete RFC
TP10: YANG prefix is cumbersome - I think 'detnet' quite long enough and likely too long - it is a shame that dtn is in use elsewhere

Not auxiliary files not updated.  They must be extracted from the draft. 

